### PR TITLE
Disable IME when system is chosen

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -161,7 +161,12 @@
 				.addClass( 'checked' );
 			ime = this.$element.data( 'ime' );
 
-			if ( !inputmethodId || inputmethodId === 'system' ) {
+			if ( inputmethodId === 'system' ) {
+				this.disableIM();
+				return;
+			}
+
+			if ( !inputmethodId ) {
 				return;
 			}
 


### PR DESCRIPTION
When system IME is chosen (or a language which has system as default is chosen), the IME description does not change, but ime is not active. This causes inconsistent behaviour when alternating between IME's after chosing IME (English is an example).

To prevent this, when system IME is chosen for any language, we explicitly disable IME.
