### PR TITLE
Fixed an error when disabling a system layout

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -96,16 +96,17 @@
 		 * @param {jQuery.Event} e
 		 */
 		keydown: function ( e ) {
-			var imeselector = this,
-				ime = $( e.target ).data( 'ime' );
+			var ime = $( e.target ).data( 'ime' );
 
 			if ( isShortcutKey( e ) ) {
 				ime.toggle();
 
-				if ( !ime.isActive() ) {
-					imeselector.disableIM();
+				if ( ime.isActive() ) {
+					if ( this.inputmethod !== null ) {
+						this.selectIM( this.inputmethod.id );
+					}
 				} else {
-					imeselector.selectIM( imeselector.inputmethod.id );
+					this.disableIM();
 				}
 
 				e.preventDefault();


### PR DESCRIPTION
Pressing Ctrl-M while a 'system' layout is active produced an error.
Now it's supposed to be prevented.
