### PR TITLE
Make IME menu only visible when needed

### DIFF
--- a/css/jquery.ime.css
+++ b/css/jquery.ime.css
@@ -8,9 +8,6 @@
 	padding: 2px 2px 1px 20px;
 	box-shadow: 0 1px 3px 0 #777;
 	margin-top: 0;
-	-webkit-transition: opacity 0.24s ease, margin-top 0.24s ease;
-	-moz-transition: opacity 0.24s ease, margin-top 0.24s ease;
-	-o-transition: opacity 0.24s ease, margin-top 0.24s ease;
 	text-align: left;
 	font-family: 'sans';
 	white-space: nowrap;

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -10,6 +10,7 @@
 		this.inputmethod = null;
 		this.init();
 		this.listen();
+		this.timer = null;
 	}
 
 	IMESelector.prototype = {
@@ -40,19 +41,45 @@
 			$( 'body' ).append( this.$imeSetting );
 		},
 
+		stopTimer: function () {
+			if(this.timer){
+				clearTimeout(this.timer);
+				this.timer = null;
+			}
+			this.$imeSetting.stop(true,true);
+		},
+
+		resetTimer: function () {
+			var imeselector = this;
+			this.stopTimer();
+			this.timer = setTimeout(
+				function(){
+					imeselector.$imeSetting.animate({"opacity":0, "marginTop": "-20px"}, 500,function(){
+						imeselector.$imeSetting.hide();
+						//Restore properties for next time it becomes visible:
+						imeselector.$imeSetting.css("opacity",1);
+						imeselector.$imeSetting.css("margin-top",0);
+					});
+				},
+				2500);
+		},
 		focus: function () {
 			// Hide all other IME settings
 			$( 'div.imeselector' ).hide();
 			this.$imeSetting.show();
+			this.resetTimer();
 		},
 
 		show: function () {
 			this.$menu.addClass( 'open' );
+			this.stopTimer();
+			this.$imeSetting.show();
 			return false;
 		},
 
 		hide: function () {
 			this.$menu.removeClass( 'open' );
+			this.resetTimer();
 			return false;
 		},
 
@@ -130,7 +157,7 @@
 		 */
 		keydown: function ( e ) {
 			var ime = $( e.target ).data( 'ime' );
-
+			this.focus(); // shows the trigger in case it is hidden
 			if ( isShortcutKey( e ) ) {
 				if ( ime.isActive() ) {
 					this.disableIM();
@@ -155,6 +182,7 @@
 		 * Position the im selector relative to the edit area
 		 */
 		position: function () {
+			this.focus();  // shows the trigger in case it is hidden
 			var position = this.$element.offset();
 
 			this.$imeSetting.css( 'top', position.top + this.$element.outerHeight() );


### PR DESCRIPTION
Makes the IME menu disappear after a timeout and makes
it visible again when the user types or clicks the input box.
- An animation (fading into the input box) is used guide the user
  how to make it reapear.
- Cancelation of animation events has been taken into account to avoid
  the menu to disappear whie open.
