### PR TITLE
Exclude .project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .*.swp
 *.kate-swp
 *.bak
+.project


### PR DESCRIPTION
Add .project to .gitignore to avoid Eclipse files to be considered by
Git
