### PR TITLE
Use of font sans-serif instead of non-standard "sans"

### DIFF
--- a/css/jquery.ime.css
+++ b/css/jquery.ime.css
@@ -9,7 +9,7 @@
 	box-shadow: 0 1px 3px 0 #777;
 	margin-top: 0;
 	text-align: left;
-	font-family: 'sans';
+	font-family: sans-serif;
 	white-space: nowrap;
 	z-index: 9999;
 }


### PR DESCRIPTION
CSS defined "sans" as font-family which is not a default font family in CSS.
This commit changes it to sans-serif which is the official name for the generic font family http://www.w3.org/TR/CSS21/fonts.html#generic-font-families
