### PR TITLE
Fix broken timer initialization.

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -8,9 +8,9 @@
 		this.$imeSetting = null;
 		this.$menu = null;
 		this.inputmethod = null;
+		this.timer = null;
 		this.init();
 		this.listen();
-		this.timer = null;
 	}
 
 	IMESelector.prototype = {


### PR DESCRIPTION
init() calls position() which calls focus(), which sets a timer.
Because the timer was set to null right after the init() call,
it was not properly cleared out. This caused a UX issue on first
load, where the IME selector would disappear right under the
mouse in spite of the recent fix to the mouseenter behavior.

It's questionable whether we want to set that timer at all on
init, but since it's now properly stopped, it's harmless.
