### PR TITLE
Correcting the native name of Lao.

### DIFF
--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -664,7 +664,7 @@
 			inputmethods: [ 'cyrl-palochka' ]
 		},
 		'lo': {
-			autonym: 'ພາສາລາວ',
+			autonym: 'ລາວ',
 			inputmethods: [ 'lo-kbd' ]
 		},
 		'mai': {


### PR DESCRIPTION
Both "ພາສາລາວ" and "ລາວ" are acceptable as the language's native name, when the former means "Lao language" and the latter means "Lao".
Take a look of http://lo.wikipedia.org/wiki/%E0%BB%81%E0%BA%A1%E0%BB%88%E0%BB%81%E0%BA%9A%E0%BA%9A:%E0%BA%9E%E0%BA%B2%E0%BA%AA%E0%BA%B2%E0%BB%84%E0%BA%97%E0%BA%81%E0%BA%B0%E0%BB%84%E0%BA%94.
In the template, the language is referred as "ລາວ".
