### PR TITLE
Remove macro-language kok

### DIFF
--- a/rules/gom/gom-inscript2.js
+++ b/rules/gom/gom-inscript2.js
@@ -1,8 +1,8 @@
 ( function ( $ ) {
 	'use strict';
 
-	var kokInScript2 = {
-		id: 'kok-inscript2',
+	var gomInScript2 = {
+		id: 'gom-inscript2',
 		name: 'कोंकणी इनस्क्रिप्ट २',
 		description: 'Enhanced InScript keyboard for Kokani language',
 		date: '2012-11-06',
@@ -112,6 +112,6 @@
 			["\\>", "ऽ"],
 			["\\.", "॥"]]
 	};
-	$.ime.register( kokInScript2 );
+	$.ime.register( gomInScript2 );
 
 }( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -284,9 +284,9 @@
 			name: 'KGP/Nudi/KP Rao',
 			source: 'rules/kn/kn-kgp.js'
 		},
-		'kok-inscript2': {
+		'gom-inscript2': {
 			name: 'इनस्क्रिप्ट २',
-			source: 'rules/kok/kok-inscript2.js'
+			source: 'rules/gom/gom-inscript2.js'
 		},
 		'ks-inscript': {
 			name: 'इनस्क्रिप्ट',
@@ -589,7 +589,7 @@
 		},
 		'gom': {
 			autonym: 'कोंकणी',
-			inputmethods: [ 'hi-transliteration', 'hi-inscript' ]
+			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'gom-inscript2' ]
 		},
 		'gu': {
 			autonym: 'ગુજરાતી',
@@ -650,10 +650,6 @@
 		'kab': {
 			autonym: 'ⵜⴰⵇⴱⴰⵢⵍⵉⵜ',
 			inputmethods: [ 'ber-tfng' ]
-		},
-		'kok': {
-			autonym: 'कोंकणी',
-			inputmethods: [ 'kok-inscript2' ]
 		},
 		'lbe': {
 			autonym: 'лакку',


### PR DESCRIPTION
Merge kok, the macro-language for different Konkani varieties, with gom,
which is the common non-macro code.
