### PR TITLE
IME button location now updates on browser zoom events

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -163,6 +163,12 @@
 			// Possible resize of textarea
 			imeselector.$element.on( 'mouseup.ime', $.proxy( this.position, this ) );
 			imeselector.$element.on( 'keydown.ime', $.proxy( this.keydown, this ) );
+
+			// Update IM selector position when window is resized
+			// or browser window is zoomed in or zoomed out
+			$( window ).resize( function () {
+				imeselector.position();
+			});
 		},
 
 		/**


### PR DESCRIPTION
IME button now remains aligned with the textarea when the browser is zoomed in or zoomed out (ctrl +/-) and also when the browser window is resized.
