### PR TITLE
Quickfix for icon position in RTL

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -204,11 +204,11 @@
 
 			position = this.$element.offset();
 			top = position.top + this.$element.outerHeight();
-			left = position.left + this.$element.outerWidth()
-				- this.$imeSetting.outerWidth();
+			left = position.left;
 			// RTL element position fix:
-			if ( this.$element.css( 'direction' ) === 'rtl' ) {
-				left = position.left;
+			if ( this.$element.css( 'direction' ) === 'ltr' ) {
+				left = position.left + this.$element.outerWidth()
+				- this.$imeSetting.outerWidth();
 			}
 			room = $( window ).height() - top;
 


### PR DESCRIPTION
The keyboard icon appeared on the right side even in RTL languages which
blocked the beginning of the typed words. This is a quickfix.
