### PR TITLE
Fixed bug 43904 (partially)

### DIFF
--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -339,6 +339,7 @@
 			if ( range && range.parentElement() === el ) {
 				len = el.value.length;
 				normalizedValue = el.value.replace( /\r\n/g, '\n' );
+				newLines = normalizedValue.match( /\n/g );
 
 				// Create a working TextRange that lives only in the input
 				textInputRange = el.createTextRange();
@@ -351,26 +352,20 @@
 				endRange.collapse( false );
 
 				if ( textInputRange.compareEndPoints( 'StartToEnd', endRange ) > -1 ) {
-					start = end = len;
+					if ( newLines ) {
+						start = end = len - newLines.length;
+					} else {
+						start = end = len;
+					}
 				} else {
 					start = -textInputRange.moveStart( 'character', -len );
-					start += normalizedValue.slice( 0, start ).split( '\n' ).length - 1;
 
 					if ( textInputRange.compareEndPoints( 'EndToEnd', endRange ) > -1 ) {
 						end = len;
 					} else {
 						end = -textInputRange.moveEnd( 'character', -len );
-						end += normalizedValue.slice( 0, end ).split( '\n' ).length - 1;
 					}
 				}
-			}
-			
-			// only find newlines till current caret position and update
-			// start and end caret positions accordingly
-			newLines = normalizedValue.substring( 0, start ).match( /\n/g );
-			if ( newLines ) {
-				start -= newLines.length;
-				end -= newLines.length;
 			}
 		}
 


### PR DESCRIPTION
Fixed replacing/overwriting characters when there is existing text in the textarea, while using internet explorer.
Tested it for Hindi and Gujarati On IE8.

One issue still remains:
The offset is calculated incorrectly while editing at the end of any paragraph that has newline character(s) after it which results in incorrect insertion.

I'm working to fix it up. Rest all cases looks good to me.
