### PR TITLE
Select the language based on pre-existing text (enhancement)

### DIFF
--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -506,6 +506,12 @@
 	* range : [a, b] both included
 	*/
 	$.extend( $.ime.languages, {
+		//Please keep 'hi' before all other devanagari script using languages. It helps in automatic selection.
+		'hi': {
+			autonym: 'हिन्दी',
+			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'hi-bolnagri', 'hi-phonetic', 'hi-inscript2' ],
+			range: ['0900','097F']
+		},
 		'ady': {
 			autonym: 'адыгэбзэ',
 			inputmethods: [ 'cyrl-palochka' ],
@@ -625,11 +631,6 @@
 			autonym: 'עברית',
 			inputmethods: [ 'he-standard-2012-extonly', 'he-standard-2012', 'he-kbd' ],
 			range: [0,0]
-		},
-		'hi': {
-			autonym: 'हिन्दी',
-			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'hi-bolnagri', 'hi-phonetic', 'hi-inscript2' ],
-			range: ['0900','097F']
 		},
 		'hr': {
 			autonym: 'Hrvatski',

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -505,311 +505,388 @@
 	$.extend( $.ime.languages, {
 		'ady': {
 			autonym: 'адыгэбзэ',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'ahr': {
 			autonym: 'अहिराणी',
-			inputmethods: [ 'mr-transliteration', 'mr-inscript' ]
+			inputmethods: [ 'mr-transliteration', 'mr-inscript' ],
+			range: [0,0]
 		},
 		'am': {
 			autonym: 'አማርኛ',
-			inputmethods: [ 'am-transliteration' ]
+			inputmethods: [ 'am-transliteration' ],
+			range: [0,0]
 		},
 		'ar': {
 			autonym: 'العربية',
-			inputmethods: [ 'ar-kbd' ]
+			inputmethods: [ 'ar-kbd' ],
+			range: [0,0]
 		},
 		'as': {
 			autonym: 'অসমীয়া',
-			inputmethods: [ 'as-transliteration', 'as-avro', 'as-bornona', 'as-inscript', 'as-phonetic', 'as-inscript2' ]
+			inputmethods: [ 'as-transliteration', 'as-avro', 'as-bornona', 'as-inscript', 'as-phonetic', 'as-inscript2' ],
+			range: [0,0]
 		},
 		'av': {
 			autonym: 'авар',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'be': {
 			autonym: 'беларуская',
-			inputmethods: [ 'be-transliteration', 'be-latin', 'be-kbd' ]
+			inputmethods: [ 'be-transliteration', 'be-latin', 'be-kbd' ],
+			range: [0,0]
 		},
 		'be-tarask': {
 			autonym: 'беларуская (тарашкевіца)',
-			inputmethods: [ 'be-transliteration', 'be-latin' ]
+			inputmethods: [ 'be-transliteration', 'be-latin' ],
+			range: [0,0]
 		},
 		'bh': {
 			autonym: 'भोजपुरी',
-			inputmethods: [ 'hi-transliteration' ]
+			inputmethods: [ 'hi-transliteration' ],
+			range: [0,0]
 		},
 		'bho': {
 			autonym: 'भोजपुरी',
-			inputmethods: [ 'hi-transliteration' ]
+			inputmethods: [ 'hi-transliteration' ],
+			range: [0,0]
 		},
 		'bn': {
 			autonym: 'বাংলা',
-			inputmethods: [ 'bn-avro', 'bn-inscript', 'bn-nkb', 'bn-probhat', 'bn-inscript2' ]
+			inputmethods: [ 'bn-avro', 'bn-inscript', 'bn-nkb', 'bn-probhat', 'bn-inscript2' ],
+			range: [0,0]
 		},
 		'brx': {
 			autonym: 'बोड़ो',
-			inputmethods: [ 'brx-inscript', 'brx-inscript2' ]
+			inputmethods: [ 'brx-inscript', 'brx-inscript2' ],
+			range: [0,0]
 		},
 		'ce': {
 			autonym: 'нохчийн',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'da': {
 			autonym: 'Dansk',
-			inputmethods: [ 'da-normforms' ]
+			inputmethods: [ 'da-normforms' ],
+			range: [0,0]
 		},
 		'de': {
 			autonym: 'Deutsch',
-			inputmethods: [ 'de' ]
+			inputmethods: [ 'de' ],
+			range: [0,0]
 		},
 		'doi': {
 			autonym: 'डोगरी',
-			inputmethods: [ 'doi-inscript2' ]
+			inputmethods: [ 'doi-inscript2' ],
+			range: [0,0]
 		},
 		'en': {
 			autonym: 'English',
-			inputmethods: [ 'ipa-sil' ]
+			inputmethods: [ 'ipa-sil' ],
+			range: [0,0]
 		},
 		'el': {
 			autonym: 'Ελληνικά',
-			inputmethods: [ 'el-kbd' ]
+			inputmethods: [ 'el-kbd' ],
+			range: [0,0]
 		},
 		'eo': {
 			autonym: 'Esperanto',
-			inputmethods: [ 'eo-transliteration', 'eo-h', 'eo-h-f', 'eo-plena', 'eo-q', 'eo-vi', 'eo-x' ]
+			inputmethods: [ 'eo-transliteration', 'eo-h', 'eo-h-f', 'eo-plena', 'eo-q', 'eo-vi', 'eo-x' ],
+			range: [0,0]
 		},
 		'fo': {
 			autonym: 'Føroyskt',
-			inputmethods: [ 'fo-normforms' ]
+			inputmethods: [ 'fo-normforms' ],
+			range: [0,0]
 		},
 		'fi': {
 			autonym: 'Suomi',
-			inputmethods: [ 'fi-transliteration' ]
+			inputmethods: [ 'fi-transliteration' ],
+			range: [0,0]
 		},
 		'gom': {
 			autonym: 'कोंकणी',
-			inputmethods: [ 'hi-transliteration', 'hi-inscript' ]
+			inputmethods: [ 'hi-transliteration', 'hi-inscript' ],
+			range: [0,0]
 		},
 		'gu': {
 			autonym: 'ગુજરાતી',
-			inputmethods: [ 'gu-transliteration', 'gu-inscript', 'gu-inscript2', 'gu-phonetic' ]
+			inputmethods: [ 'gu-transliteration', 'gu-inscript', 'gu-inscript2', 'gu-phonetic' ],
+			range: [0,0]
 		},
 		'he': {
 			autonym: 'עברית',
-			inputmethods: [ 'he-standard-2012-extonly', 'he-standard-2012', 'he-kbd' ]
+			inputmethods: [ 'he-standard-2012-extonly', 'he-standard-2012', 'he-kbd' ],
+			range: [0,0]
 		},
 		'hi': {
 			autonym: 'हिन्दी',
-			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'hi-bolnagri', 'hi-phonetic', 'hi-inscript2' ]
+			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'hi-bolnagri', 'hi-phonetic', 'hi-inscript2' ],
+			range: [0,0]
 		},
 		'hr': {
 			autonym: 'Hrvatski',
-			inputmethods: [ 'hr-kbd' ]
+			inputmethods: [ 'hr-kbd' ],
+			range: [0,0]
 		},
 		'hy': {
 			autonym: 'Հայերեն',
-			inputmethods: [ 'hy-kbd' ]
+			inputmethods: [ 'hy-kbd' ],
+			range: [0,0]
 		},
 		'hne': {
 			autonym: 'छत्तीसगढ़ी',
-			inputmethods: [ 'hi-transliteration' ]
+			inputmethods: [ 'hi-transliteration' ],
+			range: [0,0]
 		},
 		'is': {
 			autonym: 'Íslenska',
-			inputmethods: [ 'is-normforms' ]
+			inputmethods: [ 'is-normforms' ],
+			range: [0,0]
 		},
 		'fonipa': {
 			autonym: 'International Phonetic Alphabet',
-			inputmethods: [ 'ipa-sil' ]
+			inputmethods: [ 'ipa-sil' ],
+			range: [0,0]
 		},
 		'jv': {
 			autonym: 'ꦧꦱꦗꦮ',
-			inputmethods: [ 'jv-transliteration' ]
+			inputmethods: [ 'jv-transliteration' ],
+			range: [0,0]
 		},
 		'ka': {
 			autonym: 'ქართული ენა',
-			inputmethods: [ 'ka-transliteration', 'ka-kbd' ]
+			inputmethods: [ 'ka-transliteration', 'ka-kbd' ],
+			range: [0,0]
 		},
 		'kbd': {
 			autonym: 'адыгэбзэ (къэбэрдеибзэ)',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'kk': {
 			autonym: 'Қазақша',
-			inputmethods: [ 'kk-kbd', 'kk-arabic' ]
+			inputmethods: [ 'kk-kbd', 'kk-arabic' ],
+			range: [0,0]
 		},
 		'kn': {
 			autonym: 'ಕನ್ನಡ',
-			inputmethods: [ 'kn-transliteration', 'kn-inscript', 'kn-kgp', 'kn-inscript2' ]
+			inputmethods: [ 'kn-transliteration', 'kn-inscript', 'kn-kgp', 'kn-inscript2' ],
+			range: [0,0]
 		},
 		'ks': {
 			autonym: 'कॉशुर / کٲشُر',
-			inputmethods: [ 'ks-inscript', 'ks-kbd' ]
+			inputmethods: [ 'ks-inscript', 'ks-kbd' ],
+			range: [0,0]
 		},
 		'kab': {
 			autonym: 'ⵜⴰⵇⴱⴰⵢⵍⵉⵜ',
-			inputmethods: [ 'ber-tfng' ]
+			inputmethods: [ 'ber-tfng' ],
+			range: [0,0]
 		},
 		'kok': {
 			autonym: 'कोंकणी',
-			inputmethods: [ 'kok-inscript2' ]
+			inputmethods: [ 'kok-inscript2' ],
+			range: [0,0]
 		},
 		'lbe': {
 			autonym: 'лакку',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'lez': {
 			autonym: 'лезги',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'lo': {
 			autonym: 'ລາວ',
-			inputmethods: [ 'lo-kbd' ]
+			inputmethods: [ 'lo-kbd' ],
+			range: [0,0]
 		},
 		'mai': {
 			autonym: 'मैथिली',
-			inputmethods: [ 'mai-inscript', 'mai-inscript2' ]
+			inputmethods: [ 'mai-inscript', 'mai-inscript2' ],
+			range: [0,0]
 		},
 		'mh': {
 			autonym: 'Kajin M̧ajeļ',
-			inputmethods: [ 'mh' ]
+			inputmethods: [ 'mh' ],
+			range: [0,0]
 		},
 		'ml': {
 			autonym: 'മലയാളം',
-			inputmethods: [ 'ml-transliteration', 'ml-inscript', 'ml-inscript2' ]
+			inputmethods: [ 'ml-transliteration', 'ml-inscript', 'ml-inscript2' ],
+			range: [0,0]
 		},
 		'mn': {
 			autonym: 'Монгол',
-			inputmethods: [ 'mn-cyrl' ]
+			inputmethods: [ 'mn-cyrl' ],
+			range: [0,0]
 		},
 		'mni': {
 			autonym: 'Manipuri',
-			inputmethods: [ 'mni-inscript2' ]
+			inputmethods: [ 'mni-inscript2' ],
+			range: [0,0]
 		},
 		'mr': {
 			autonym: 'मराठी',
-			inputmethods: [ 'mr-transliteration', 'mr-inscript2', 'mr-inscript', 'mr-phonetic' ]
+			inputmethods: [ 'mr-transliteration', 'mr-inscript2', 'mr-inscript', 'mr-phonetic' ],
+			range: [0,0]
 		},
 		'my': {
 			autonym: 'မြန်မာ',
-			inputmethods: [ 'my-kbd', 'my-xkb' ]
+			inputmethods: [ 'my-kbd', 'my-xkb' ],
+			range: [0,0]
 		},
 		'ne': {
 			autonym: 'नेपाली',
-			inputmethods: [ 'ne-transliteration', 'ne-inscript2', 'ne-inscript', 'ne-rom', 'ne-trad' ]
+			inputmethods: [ 'ne-transliteration', 'ne-inscript2', 'ne-inscript', 'ne-rom', 'ne-trad' ],
+			range: [0,0]
 		},
 		'new': {
 			autonym: 'नेपाल भाषा',
-			inputmethods: [ 'hi-transliteration', 'hi-inscript' ]
+			inputmethods: [ 'hi-transliteration', 'hi-inscript' ],
+			range: [0,0]
 		},
 		'no': {
 			autonym: 'Norsk',
-			inputmethods: [ 'no-normforms', 'no-tildeforms' ]
+			inputmethods: [ 'no-normforms', 'no-tildeforms' ],
+			range: [0,0]
 		},
 		'nb': {
 			autonym: 'Norsk (bokmål)',
-			inputmethods: [ 'no-normforms', 'no-tildeforms' ]
+			inputmethods: [ 'no-normforms', 'no-tildeforms' ],
+			range: [0,0]
 		},
 		'nn': {
 			autonym: 'Norsk (nynorsk)',
-			inputmethods: [ 'no-normforms', 'no-tildeforms' ]
+			inputmethods: [ 'no-normforms', 'no-tildeforms' ],
+			range: [0,0]
 		},
 		'or': {
 			autonym: 'ଓଡ଼ିଆ',
-			inputmethods: [ 'or-transliteration', 'or-lekhani', 'or-inscript', 'or-phonetic', 'or-inscript2' ]
+			inputmethods: [ 'or-transliteration', 'or-lekhani', 'or-inscript', 'or-phonetic', 'or-inscript2' ],
+			range: [0,0]
 		},
 		'pa': {
 			autonym: 'ਪੰਜਾਬੀ',
-			inputmethods: [ 'pa-transliteration', 'pa-inscript', 'pa-phonetic', 'pa-inscript2', 'pa-jhelum' ]
+			inputmethods: [ 'pa-transliteration', 'pa-inscript', 'pa-phonetic', 'pa-inscript2', 'pa-jhelum' ],
+			range: [0,0]
 		},
 		'rif': {
 			autonym: 'ⵜⴰⵔⵉⴼⵉⵜ',
-			inputmethods: [ 'ber-tfng' ]
+			inputmethods: [ 'ber-tfng' ],
+			range: [0,0]
 		},
 		'ru': {
 			autonym: 'русский',
-			inputmethods: [ 'ru-jcuken', 'ru-kbd', 'ru-phonetic', 'ru-yawerty' ]
+			inputmethods: [ 'ru-jcuken', 'ru-kbd', 'ru-phonetic', 'ru-yawerty' ],
+			range: [0,0]
 		},
 		'sah': {
 			autonym: 'саха тыла',
-			inputmethods: [ 'sah-transliteration' ]
+			inputmethods: [ 'sah-transliteration' ],
+			range: [0,0]
 		},
 		'sa': {
 			autonym: 'संस्कृत',
-			inputmethods: [ 'sa-transliteration', 'sa-inscript2', 'sa-inscript' ]
+			inputmethods: [ 'sa-transliteration', 'sa-inscript2', 'sa-inscript' ],
+			range: [0,0]
 		},
 		'sat': {
 			autonym: 'संताली',
-			inputmethods: [ 'sat-inscript2']
+			inputmethods: [ 'sat-inscript2'],
+			range: [0,0]
 		},
 		'sd': {
 			autonym: 'सिंधी',
-			inputmethods: [ 'sd-inscript2' ]
+			inputmethods: [ 'sd-inscript2' ],
+			range: [0,0]
 		},
 		'se': {
 			autonym: 'Davvisámegiella',
-			inputmethods: [ 'se-normforms' ]
+			inputmethods: [ 'se-normforms' ],
+			range: [0,0]
 		},
 		'shi': {
 			autonym: 'ⵜⴰⵛⵍⵃⵉⵜ',
-			inputmethods: [ 'ber-tfng' ]
+			inputmethods: [ 'ber-tfng' ],
+			range: [0,0]
 		},
 		'si': {
 			autonym: 'සිංහල',
-			inputmethods: [ 'si-singlish', 'si-wijesekara' ]
+			inputmethods: [ 'si-singlish', 'si-wijesekara' ],
+			range: [0,0]
 		},
 		'sk': {
 			autonym: 'Slovenčina',
-			inputmethods: [ 'sk-kbd' ]
+			inputmethods: [ 'sk-kbd' ],
+			range: [0,0]
 		},
 		'sr': {
 			autonym: 'Српски / srpski',
-			inputmethods: [ 'sr-kbd' ]
+			inputmethods: [ 'sr-kbd' ],
+			range: [0,0]
 		},
 		'sv': {
 			autonym: 'Svenska',
-			inputmethods: [ 'sv-normforms' ]
+			inputmethods: [ 'sv-normforms' ],
+			range: [0,0]
 		},
 		'ta': {
 			autonym: 'தமிழ்',
-			inputmethods: [ 'ta-transliteration', 'ta-99', 'ta-inscript', 'ta-bamini', 'ta-inscript2' ]
+			inputmethods: [ 'ta-transliteration', 'ta-99', 'ta-inscript', 'ta-bamini', 'ta-inscript2' ],
+			range: [0,0]
 		},
 		'tcy': {
 			autonym: 'ತುಳು',
-			inputmethods: [ 'kn-transliteration' ]
+			inputmethods: [ 'kn-transliteration' ],
+			range: [0,0]
 		},
 		'te': {
 			autonym: 'తెలుగు',
-			inputmethods: [ 'te-transliteration', 'te-inscript', 'te-inscript2' ]
+			inputmethods: [ 'te-transliteration', 'te-inscript', 'te-inscript2' ],
+			range: [0,0]
 		},
 		'th': {
 			autonym: 'ไทย',
-			inputmethods: [ 'th-kedmanee', 'th-pattachote' ]
+			inputmethods: [ 'th-kedmanee', 'th-pattachote' ],
+			range: [0,0]
 		},
 		'tkr': {
 			autonym: 'цӀаӀхна миз',
-			inputmethods: [ 'cyrl-palochka' ]
+			inputmethods: [ 'cyrl-palochka' ],
+			range: [0,0]
 		},
 		'tzm': {
 			autonym: 'ⵜⴰⵎⴰⵣⵉⵖⵜ',
-			inputmethods: [ 'ber-tfng' ]
+			inputmethods: [ 'ber-tfng' ],
+			range: [0,0]
 		},
 		'uk': {
 			autonym: 'Українська',
-			inputmethods: [ 'uk-kbd' ]
+			inputmethods: [ 'uk-kbd' ],
+			range: [0,0]
 		},
 		'ug': {
 			autonym: 'ئۇيغۇرچە / Uyghurche',
-			inputmethods: [ 'ug-kbd' ]
+			inputmethods: [ 'ug-kbd' ],
+			range: [0,0]
 		},
 		'ur': {
 			autonym: 'اردو',
-			inputmethods: [ 'ur-transliteration', 'ur-phonetic' ]
+			inputmethods: [ 'ur-transliteration', 'ur-phonetic' ],
+			range: [0,0]
 		},
 		'uz': {
 			autonym: 'Oʻzbekcha',
-			inputmethods: [ 'uz-kbd' ]
+			inputmethods: [ 'uz-kbd' ],
+			range: [0,0]
 		}
 	} );
 

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -502,6 +502,9 @@
 		}
 	} );
 
+	/**
+	* range : [a, b] both included
+	*/
 	$.extend( $.ime.languages, {
 		'ady': {
 			autonym: 'адыгэбзэ',
@@ -516,17 +519,17 @@
 		'am': {
 			autonym: 'አማርኛ',
 			inputmethods: [ 'am-transliteration' ],
-			range: [0,0]
+			range: ['1200','137F']
 		},
 		'ar': {
 			autonym: 'العربية',
 			inputmethods: [ 'ar-kbd' ],
-			range: [0,0]
+			range: ['0600','06FF']
 		},
 		'as': {
 			autonym: 'অসমীয়া',
 			inputmethods: [ 'as-transliteration', 'as-avro', 'as-bornona', 'as-inscript', 'as-phonetic', 'as-inscript2' ],
-			range: [0,0]
+			range: ['0980','09FF']
 		},
 		'av': {
 			autonym: 'авар',
@@ -556,7 +559,7 @@
 		'bn': {
 			autonym: 'বাংলা',
 			inputmethods: [ 'bn-avro', 'bn-inscript', 'bn-nkb', 'bn-probhat', 'bn-inscript2' ],
-			range: [0,0]
+			range: ['0980','09FF']
 		},
 		'brx': {
 			autonym: 'बोड़ो',
@@ -571,7 +574,7 @@
 		'da': {
 			autonym: 'Dansk',
 			inputmethods: [ 'da-normforms' ],
-			range: [0,0]
+			range: ['01FA','01FF']
 		},
 		'de': {
 			autonym: 'Deutsch',
@@ -591,7 +594,7 @@
 		'el': {
 			autonym: 'Ελληνικά',
 			inputmethods: [ 'el-kbd' ],
-			range: [0,0]
+			range: ['0374', '03FF']
 		},
 		'eo': {
 			autonym: 'Esperanto',
@@ -616,7 +619,7 @@
 		'gu': {
 			autonym: 'ગુજરાતી',
 			inputmethods: [ 'gu-transliteration', 'gu-inscript', 'gu-inscript2', 'gu-phonetic' ],
-			range: [0,0]
+			range: ['0A80','0AFF']
 		},
 		'he': {
 			autonym: 'עברית',
@@ -626,7 +629,7 @@
 		'hi': {
 			autonym: 'हिन्दी',
 			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'hi-bolnagri', 'hi-phonetic', 'hi-inscript2' ],
-			range: [0,0]
+			range: ['0900','097F']
 		},
 		'hr': {
 			autonym: 'Hrvatski',
@@ -776,7 +779,7 @@
 		'pa': {
 			autonym: 'ਪੰਜਾਬੀ',
 			inputmethods: [ 'pa-transliteration', 'pa-inscript', 'pa-phonetic', 'pa-inscript2', 'pa-jhelum' ],
-			range: [0,0]
+			range: ['0A00','0A7F']
 		},
 		'rif': {
 			autonym: 'ⵜⴰⵔⵉⴼⵉⵜ',
@@ -796,7 +799,7 @@
 		'sa': {
 			autonym: 'संस्कृत',
 			inputmethods: [ 'sa-transliteration', 'sa-inscript2', 'sa-inscript' ],
-			range: [0,0]
+			range: ['0900','097F']
 		},
 		'sat': {
 			autonym: 'संताली',
@@ -866,7 +869,7 @@
 		'tzm': {
 			autonym: 'ⵜⴰⵎⴰⵣⵉⵖⵜ',
 			inputmethods: [ 'ber-tfng' ],
-			range: [0,0]
+			range: ['2D30','2D7F']
 		},
 		'uk': {
 			autonym: 'Українська',

--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -258,6 +258,16 @@
 		 */
 		lastNChars: function ( str, pos, n ) {
 			return lastNChars( str, pos, n );
+		},
+		
+		/**
+		 * Get the hex code of first character of the string passed.
+		 * 
+		 * @param ch String
+		 * @return A 4 letter hexcode, like 02AF.
+		 */
+		getHexcode : function ( ch ) {
+			return getHexcode( ch );
 		}
 	};
 
@@ -464,6 +474,25 @@
 		}
 	}
 
+	/**
+	 * Get the hex code of first character of the string passed.
+	 * 
+	 * @param ch String
+	 * @return A 4 letter hexcode, like 02AF.
+	 */
+	function getHexcode( ch ){
+		if(ch === '' || ch === null){
+			return;
+		}
+		var code, hex;
+		code = ch.charCodeAt(0);
+		hex = code.toString(16).toUpperCase();
+		while (hex.length < 4) {
+			hex = "0" + hex;
+		}
+		return hex;		
+	}
+	
 	function arrayKeys ( obj ) {
 		var rv = [];
 		$.each( obj, function ( key ) {

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -294,12 +294,6 @@
 		 *
 		 */
 		decideLanguage : function () {
-			// Try to match the language using already present text, if possible
-			if( this.matchLanguage() ){
-				var matched = this.matchLanguage();				
-				return matched[0];
-			}
-						
 			if( $.ime.preferences.getLanguage() ) {
 				// There has been an override by the user return the language selected by user
 				return $.ime.preferences.getLanguage();
@@ -310,6 +304,12 @@
 					return this.$element.attr('lang');
 			}
 			// There is either no IMs for the given language attr or there is no lang attr at all.
+			
+			// Try to match the language using already present text, if possible
+			if( this.matchLanguage() ){
+				var matched = this.matchLanguage();				
+				return matched[0];
+			}
 			
 			return $.ime.preferences.getDefaultLanguage();
 		},

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -148,10 +148,13 @@
 				e.preventDefault();
 			} );
 
+			//Delay by 1ms to allow getCaretPosition capture the cursor location on focus.
 			imeselector.$element.on( 'focus.ime', function ( e ) {
+				setTimeout( function ( ) {
 				imeselector.selectLanguage( imeselector.decideLanguage() );
 				imeselector.focus();
 				e.stopPropagation();
+				}, 1 );
 			} );
 
 			imeselector.$element.attrchange( function ( ) {
@@ -293,23 +296,29 @@
 		decideLanguage : function () {
 			// Try to match the language using already present text, if possible
 			if( this.matchLanguage() ){
-				var matched = this.matchLanguage();
+				var matched = this.matchLanguage();				
 				return matched[0];
 			}
-			
+						
 			if( $.ime.preferences.getLanguage() ) {
 				// There has been an override by the user return the language selected by user
 				return $.ime.preferences.getLanguage();
 			}
+			
 			if ( this.$element.attr('lang') &&
 				$.ime.languages[this.$element.attr('lang')] ) {
 					return this.$element.attr('lang');
 			}
 			// There is either no IMs for the given language attr or there is no lang attr at all.
+			
 			return $.ime.preferences.getDefaultLanguage();
 		},
 		
-		matchLanguage : function(){
+		/**
+		*  Match the language using already present text
+		*
+		*/
+		matchLanguage : function () {
 			var ime, pos, cursorPos, input, hex, languageCode;
 			
 			ime = this.$element.data('ime');
@@ -596,4 +605,3 @@
 
 
 }( jQuery ) );
-

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -318,25 +318,30 @@
 		*  Match the language using already present text
 		*
 		*/
-		matchLanguage : function () {
-			var ime, pos, cursorPos, input, hex, languageCode;
+		matchLanguage : function (cursorPos){
+			var ime, pos, input, hex, languageCode;
 			
 			ime = this.$element.data('ime');
-			pos = ime.getCaretPosition(this.$element);
-			cursorPos = pos[1]>pos[0] ? pos[0]+1 : pos[0];
-			if(!cursorPos){
-				cursorPos = 1;
+			if(typeof cursorPos === 'undefined'){
+				pos = ime.getCaretPosition(this.$element);
+				cursorPos = pos[1]>pos[0] ? pos[0]+1 : pos[0];
+				if(!cursorPos){
+					cursorPos = 1;
+				}
 			}
 			
 			input = ime.lastNChars( this.$element.val() || this.$element.text(), cursorPos, 1 );
 			hex = ime.getHexcode(input);
 			if(hex === 'undefined'){
 				return;
+			//get one more character, if this is a special char
+			}else if(hex >= '0020' && hex <= '002F') {
+				return this.matchLanguage( --cursorPos );
 			}
 			
-			var ranges = $.ime.languages;
+			var langs = $.ime.languages;
 			var languageCode = [];
-			$.each(ranges, function(langCode, l){
+			$.each(langs, function(langCode, l){
 				if(hex >= l.range[0] && hex <= l.range[1]){
 					languageCode.push(langCode);
 				}

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -291,6 +291,11 @@
 		 *
 		 */
 		decideLanguage : function () {
+			// Try to match the language using already present text, if possible
+			if( this.matchLanguage() ){
+				return this.matchLanguage();
+			}
+			
 			if( $.ime.preferences.getLanguage() ) {
 				// There has been an override by the user return the language selected by user
 				return $.ime.preferences.getLanguage();
@@ -301,6 +306,28 @@
 			}
 			// There is either no IMs for the given language attr or there is no lang attr at all.
 			return $.ime.preferences.getDefaultLanguage();
+		},
+		
+		matchLanguage : function(){
+			var ime, pos, cursorPos, input, hex, languageCode;
+			
+			ime = this.$element.data('ime');
+			pos = ime.getCaretPosition(this.$element);
+			cursorPos = pos[1]>pos[0] ? pos[1] : pos[0];
+			
+			input = ime.lastNChars( this.$element.val() || this.$element.text(), cursorPos, 1 );
+			hex = ime.getHexcode(input);
+			
+			var ranges = $.ime.languages;
+			var languageCode = null;
+			$.each(ranges, function(langCode, l){
+				if(hex >= l.range[0] && hex <= l.range[1]){
+					languageCode = langCode;
+				}
+				return !languageCode;
+			});
+			
+			return languageCode;
 		},
 
 		/**

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -316,11 +316,14 @@
 			pos = ime.getCaretPosition(this.$element);
 			cursorPos = pos[1]>pos[0] ? pos[0]+1 : pos[0];
 			if(!cursorPos){
-				return false;
+				cursorPos = 1;
 			}
 			
 			input = ime.lastNChars( this.$element.val() || this.$element.text(), cursorPos, 1 );
 			hex = ime.getHexcode(input);
+			if(hex === 'undefined'){
+				return;
+			}
 			
 			var ranges = $.ime.languages;
 			var languageCode = [];

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -307,8 +307,9 @@
 			
 			// Try to match the language using already present text, if possible
 			if( this.matchLanguage() ){
-				var matched = this.matchLanguage();				
-				return matched[0];
+				var matched = this.matchLanguage();
+				this.prepareInputMethods(matched[0]);
+				return;
 			}
 			
 			return $.ime.preferences.getDefaultLanguage();

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -293,7 +293,8 @@
 		decideLanguage : function () {
 			// Try to match the language using already present text, if possible
 			if( this.matchLanguage() ){
-				return this.matchLanguage();
+				var matched = this.matchLanguage();
+				return matched[0];
 			}
 			
 			if( $.ime.preferences.getLanguage() ) {
@@ -313,18 +314,20 @@
 			
 			ime = this.$element.data('ime');
 			pos = ime.getCaretPosition(this.$element);
-			cursorPos = pos[1]>pos[0] ? pos[1] : pos[0];
+			cursorPos = pos[1]>pos[0] ? pos[0]+1 : pos[0];
+			if(!cursorPos){
+				return false;
+			}
 			
 			input = ime.lastNChars( this.$element.val() || this.$element.text(), cursorPos, 1 );
 			hex = ime.getHexcode(input);
 			
 			var ranges = $.ime.languages;
-			var languageCode = null;
+			var languageCode = [];
 			$.each(ranges, function(langCode, l){
 				if(hex >= l.range[0] && hex <= l.range[1]){
-					languageCode = langCode;
+					languageCode.push(langCode);
 				}
-				return !languageCode;
 			});
 			
 			return languageCode;


### PR DESCRIPTION
(Issue #97) Not completely ready.
It adds a 'range' of hex code points to every language listed in inputmethods.js.
Issue: on chrome, works only when the cursor is in text field and you change the tab, and return back to the same tab... strange. On IE, works well.

Tested with hindi, gujarati and punjabi.

Todo:
- Add all the matched languages to selector menu.
- Update the code point ranges for all the languages.
- Use more characters from the text (currently only one character just before the cursor is used).
