### PR TITLE
Fixed imeselector position when page is scrolled

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -212,7 +212,12 @@
 			top = position.top + this.$element.outerHeight();
 			left = position.left + this.$element.outerWidth()
 				- this.$imeSetting.outerWidth();
-			room = $( window ).height() - top;
+			
+			// While determining whether to place the selector above or below the input box,
+			// take into account the value of scrollTop to avoid the selector from always 
+			// getting placed above the input box since window.height would be less than top
+			// if the page has been scrolled.
+			room = $( window ).height() + $( document ).scrollTop() - top;
 
 			if ( room < this.$imeSetting.outerHeight() ) {
 				top = position.top - this.$imeSetting.outerHeight();


### PR DESCRIPTION
Bug - When the page is scrolled, the imeselector is always placed above the textarea regardless of the amount of room available below the textarea.

This bug is now fixed.

Now imeselector is placed either above or below the textarea depending upon the amount of room available below the textarea even when the page is scrolled.
