### PR TITLE
Added keyboard shortcut to toggle between active layouts (Issue #148)

### DIFF
--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -5,6 +5,9 @@
 		this.$element = $( element );
 		// This needs to be delayed here since extending language list happens at DOM ready
 		$.ime.defaults.languages = arrayKeys( $.ime.languages );
+		// Load previous input methods from local storage
+		// It should probably take place somewhere else.
+		$.ime.preferences.loadLayoutHistory();
 		this.options = $.extend( {}, $.ime.defaults, options );
 		this.active = false;
 		this.inputmethod = null;

--- a/src/jquery.ime.preferences.js
+++ b/src/jquery.ime.preferences.js
@@ -6,6 +6,8 @@
 			isDirty: false,
 			language : null,
 			previousLanguages: [], // array of previous languages
+			layoutHistory: [ 'system' ], // array containing previously used layouts
+			layoutHistorySize: 5, // Max no. of input methods that will be saved including system input
 			imes: {
 				'en': 'system'
 			}
@@ -54,6 +56,7 @@
 
 			this.registry.imes[this.getLanguage()] = inputMethod;
 			this.registry.isDirty = true;
+			this.saveLayoutHistory( inputMethod );
 		},
 
 		// Return the last used or the default IM for language
@@ -70,6 +73,49 @@
 
 		load: function () {
 			// load registry from cookies or localstorage
+		},
+
+		// save the current layout or input method in layoutHistory
+		saveLayoutHistory: function ( inputMethod ) {
+			// do not save if input method is system, or if it is already present in layoutHistory
+			// using jquery's equivalent of array.indexOf since it is not supported in IE7,8.
+			if ( inputMethod === 'system' || $.inArray( inputMethod, this.registry.layoutHistory ) !== -1 ) {
+				return;
+			}
+
+			// layoutHistory is full. Remove the least recently used input method. The first 
+			// position (or zeroth index) is always reserved for system input method. So the 
+			// least recenlty used input method will reside at 2nd position (or 1st index) of layoutHistory
+			if ( this.registry.layoutHistory.length === this.registry.layoutHistorySize ) {
+				this.registry.layoutHistory.splice( 1, 1 );
+			}
+			this.registry.layoutHistory.push( inputMethod );
+
+			// save layoutHistory in local storage
+			if ( ( 'localStorage' in window ) && window['localStorage'] !== null ) {
+				localStorage.setItem( "jquery.ime.layoutHistory", JSON.stringify( this.registry.layoutHistory ) );
+			}
+		},
+
+		// return the last used layout or input method
+		getPreviousLayout: function () {
+			var layoutHistoryIndex = $.inArray( this.getIM( this.getLanguage() ), this.registry.layoutHistory );
+			// currently using system input method (zeroth index)
+			if ( layoutHistoryIndex === 0 ) {
+				layoutHistoryIndex = this.registry.layoutHistory.length - 1;
+			} else {
+				--layoutHistoryIndex;
+			}
+			return this.registry.layoutHistory[layoutHistoryIndex];
+		},
+
+		// load previously used layouts from local storage
+		loadLayoutHistory: function () {
+			if ( ( 'localStorage' in window ) && window['localStorage'] !== null ) {
+				if ( localStorage.getItem( "jquery.ime.layoutHistory" ) !== null ) {
+					this.registry.layoutHistory = JSON.parse( localStorage.getItem( "jquery.ime.layoutHistory" ) );
+				}
+			}
 		}
 	} );
 }( jQuery ) );

--- a/src/jquery.ime.preferences.js
+++ b/src/jquery.ime.preferences.js
@@ -6,8 +6,8 @@
 			isDirty: false,
 			language : null,
 			previousLanguages: [], // array of previous languages
-			layoutHistory: [ 'system' ], // array containing previously used layouts
-			layoutHistorySize: 5, // Max no. of input methods that will be saved including system input
+			layoutHistory: [], // array containing previously used layouts
+			layoutHistorySize: 4, // Max no. of input methods that will be saved
 			imes: {
 				'en': 'system'
 			}
@@ -56,7 +56,6 @@
 
 			this.registry.imes[this.getLanguage()] = inputMethod;
 			this.registry.isDirty = true;
-			this.saveLayoutHistory( inputMethod );
 		},
 
 		// Return the last used or the default IM for language
@@ -77,17 +76,20 @@
 
 		// save the current layout or input method in layoutHistory
 		saveLayoutHistory: function ( inputMethod ) {
-			// do not save if input method is system, or if it is already present in layoutHistory
-			// using jquery's equivalent of array.indexOf since it is not supported in IE7,8.
-			if ( inputMethod === 'system' || $.inArray( inputMethod, this.registry.layoutHistory ) !== -1 ) {
+			// do not save if input method is system
+			if ( inputMethod === 'system' ) {
 				return;
 			}
 
-			// layoutHistory is full. Remove the least recently used input method. The first 
-			// position (or zeroth index) is always reserved for system input method. So the 
-			// least recenlty used input method will reside at 2nd position (or 1st index) of layoutHistory
+			// input method already present in layoutHistory. Remove it from
+			// its current location and insert in the end.
+			if ( $.inArray( inputMethod, this.registry.layoutHistory ) !== -1 ) {
+				this.registry.layoutHistory.splice( $.inArray( inputMethod, this.registry.layoutHistory ), 1 );
+			}
+
+			// layoutHistory is full. Remove the least recently used input method.
 			if ( this.registry.layoutHistory.length === this.registry.layoutHistorySize ) {
-				this.registry.layoutHistory.splice( 1, 1 );
+				this.registry.layoutHistory.splice( 0, 1 );
 			}
 			this.registry.layoutHistory.push( inputMethod );
 
@@ -101,7 +103,7 @@
 		getPreviousLayout: function () {
 			var layoutHistoryIndex = $.inArray( this.getIM( this.getLanguage() ), this.registry.layoutHistory );
 			// currently using system input method (zeroth index)
-			if ( layoutHistoryIndex === 0 ) {
+			if ( layoutHistoryIndex === -1 || layoutHistoryIndex === 0 ) {
 				layoutHistoryIndex = this.registry.layoutHistory.length - 1;
 			} else {
 				--layoutHistoryIndex;

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -9,6 +9,7 @@
 		this.$menu = null;
 		this.inputmethod = null;
 		this.timer = null;
+		this.ctrlKeyPressed = false;
 		this.init();
 		this.listen();
 	}
@@ -133,11 +134,13 @@
 
 			imeselector.$menu.on( 'click.ime', 'li.ime-im', function ( e ) {
 				imeselector.selectIM( $( this ).data( 'ime-inputmethod' ) );
+				$.ime.preferences.saveLayoutHistory( $( this ).data( 'ime-inputmethod' ) );
 				e.stopPropagation();
 			} );
 
 			imeselector.$menu.on( 'click.ime', 'li.ime-lang', function ( e ) {
 				imeselector.selectLanguage( $( this ).attr( 'lang' ) );
+				$.ime.preferences.saveLayoutHistory( $.ime.preferences.getIM( $( this ).attr( 'lang' ) ) );
 				e.stopPropagation();
 				e.preventDefault();
 			} );
@@ -163,6 +166,7 @@
 			// Possible resize of textarea
 			imeselector.$element.on( 'mouseup.ime', $.proxy( this.position, this ) );
 			imeselector.$element.on( 'keydown.ime', $.proxy( this.keydown, this ) );
+			imeselector.$element.on( 'keyup.ime', $.proxy( this.keyup, this ) );
 
 			// Update IM selector position when window is resized
 			// or browser window is zoomed in or zoomed out
@@ -196,13 +200,31 @@
 
 				return false;
 			} else if ( isToggleLayoutShortcut( e ) ) {
-				this.selectIM ( $.ime.preferences.getPreviousLayout() );
+				this.ctrlKeyPressed = true;
+				this.selectIM( $.ime.preferences.getPreviousLayout() );
 				e.preventDefault();
 				e.stopPropagation();
 				return false;
 			}
 
 			return true;
+		},
+
+		/**
+		 * Keyup event handler. Handles  keyup events for shortcut key
+		 *
+		 * @context {HTMLElement}
+		 * @param {jQuery.Event} e
+		 */
+		keyup: function ( e ) {
+			// e.ctrlKey is not working on keyup, need to look into it
+			// using e.which until then
+			if ( this.ctrlKeyPressed && e.which === 17 ) {
+				this.ctrlKeyPressed = false;
+				if ( this.inputmethod !== null ) {
+					$.ime.preferences.saveLayoutHistory( this.inputmethod.id );
+				}
+			}
 		},
 
 		/**
@@ -512,8 +534,8 @@
 	 * @return bool
 	 */
 	function isToggleLayoutShortcut ( event ) {
-		// 76 - The letter L, for Ctrl + L
-		return event.ctrlKey && ( event.which === 76 );
+		// 81 - The letter Q, for Ctrl + Q
+		return event.ctrlKey && ( event.which === 81 );
 	}
 
 	function isDOMAttrModifiedSupported () {

--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -195,6 +195,11 @@
 				e.stopPropagation();
 
 				return false;
+			} else if ( isToggleLayoutShortcut( e ) ) {
+				this.selectIM ( $.ime.preferences.getPreviousLayout() );
+				e.preventDefault();
+				e.stopPropagation();
+				return false;
 			}
 
 			return true;
@@ -498,6 +503,17 @@
 		// 77 - The letter M, for Ctrl-M
 		// 13 - The Enter key
 		return event.ctrlKey && ( event.which === 77 || event.which === 13 );
+	}
+
+	/**
+	 * Check whether a keypress event corresponds to the toggle layout shortcut key
+	 *
+	 * @param event Event object
+	 * @return bool
+	 */
+	function isToggleLayoutShortcut ( event ) {
+		// 76 - The letter L, for Ctrl + L
+		return event.ctrlKey && ( event.which === 76 );
 	}
 
 	function isDOMAttrModifiedSupported () {


### PR DESCRIPTION
I have added the functionality to save user's last 4 input method choices in browser's local storage.

Based on my discussion with Pau Giner, the approach is:

We can toggle between these 4 choices using the keyboard shortcut (Ctrl + Q). This works in the same way that ALT+TAB allows you to switch between windows in most operating systems. This means that switching between the two most recent languages involves only one keystroke. Switching between further languages would involve many initial keystrokes but from that point you will only need one to switch between those.

You can see a demo here: http://praveensingh.in/jquery.ime/examples/

It works well on Firefox and Chrome.
I tried to test it on IE under virtualbox but the keyboard shortcuts were not working altogether, not even the disable IME shortcut Ctrl + M (Is it a bug?).

Local storage is supported across all major browsers. See http://caniuse.com/namevalue-storage
The total number of choices to be saved, and the keyboard shortcut key to toggle input methods can easily be changed if required.
