### PR TITLE
Use consistent naming for input methods

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -396,7 +396,7 @@
 				ime.enable();
 				ime.setIM( inputmethodId );
 				imeselector.$imeSetting.find( 'a.ime-name' ).text(
-					imeselector.inputmethod.name
+					$.ime.sources[inputmethodId].name
 				);
 
 				imeselector.position();


### PR DESCRIPTION
This will fix inconsistency in naming for input methods in menu
and keyboard name shown next to icon.

Bug: 50939
