### PR TITLE
Fix dependency loading

### DIFF
--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -266,10 +266,15 @@
 			dependency = $.ime.sources[inputmethodId].depends;
 			if ( dependency && !$.ime.inputmethods[dependency] ) {
 				ime.load( dependency ).done( function () {
-					ime.load( inputmethodId )
+					ime.load( inputmethodId ).done( function () {
+						deferred.resolve();
+					} );
 				} );
+
+				return deferred;
 			}
 
+			debug( 'Loading ' + inputmethodId );
 			deferred = $.getScript(
 				ime.options.imePath + $.ime.sources[inputmethodId].source
 			).done( function () {


### PR DESCRIPTION
Loading an IM with dependencies resulted in infinite recursion.
This patch fixes it by loading the dependency only if it's
not loaded already.
