### PR TITLE
Fix Oriya transliteration name

### DIFF
--- a/rules/or/or-transliteration.js
+++ b/rules/or/or-transliteration.js
@@ -3,8 +3,8 @@
 
 	var orTransliteration = {
 		id: 'or-transliteration',
-		// TODO: it's unclear what do these control characters do here
-		name: 'ଟ୍ରାନ୍ସଲିଟରେସନ',
+		name: 'ଟ୍ରାନ୍ସଲିଟରେସନ',
+
 		description: 'Odia Transliteration',
 		date: '2012-10-14',
 		URL: 'http://github.com/wikimedia/jquery.ime',

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -369,7 +369,7 @@
 			source: 'rules/no/no-tildeforms.js'
 		},
 		'or-transliteration': {
-			name: 'ଟ୍ରାନ୍ସଲି ଟରେସନ',
+			name: 'ଟ୍ରାନ୍ସଲିଟରେସନ',
 			source: 'rules/or/or-transliteration.js'
 		},
 		'or-inscript': {


### PR DESCRIPTION
Removing unnecessary spaces and control characters.

This was checked by Subhashish at Wikimania.
