### PR TITLE
Do not prevent default 'click' action of everything on the page

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -131,7 +131,9 @@
 			} );
 
 			// Hide the menu when clicked outside
-			$( 'html' ).click( $.proxy( this.hide, this ) );
+			$( 'html' ).click( function () {
+				imeselector.hide();
+			} );
 
 			// ... but when clicked on window do not propagate it.
 			this.$menu.on( 'click', function ( event ) {


### PR DESCRIPTION
IMESelector#hide returns false, preventing all other click
handlers, including browser's native ones, from running.
Wrap it in a good ol' closure instead of using jQuery.proxy.
Fixes bug 53041. 

Untested.
