### PR TITLE
Add support for the getAutonym callback

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -351,7 +351,6 @@
 			this.$menu.find( 'li.ime-lang' ).show();
 			this.$menu.find( 'li[lang=' + languageCode + ']' ).hide();
 
-			this.setMenuTitle( language.autonym );
 			this.prepareInputMethods( languageCode );
 			this.hide();
 			// And select the default inputmethod
@@ -481,7 +480,7 @@
 
 				$languageItem = $( '<a>' )
 					.attr( 'href', '#' )
-					.text( language.autonym )
+					.text( this.getAutonym() )
 					.addClass( 'selectable-row-item' );
 				$language = $( '<li class="ime-lang selectable-row">' ).attr( 'lang', languageCode );
 				$language.append( $languageItem );


### PR DESCRIPTION
A getAutonym function can be passed as an option
when initializing ime, to give a possibility to load
autonyms of languages that don't have input methods
defined.

This is a step to resolving the following downstream bug:
https://bugzilla.wikimedia.org/show_bug.cgi?id=51025
