### PR TITLE
Revert "Pass rangy as a parameter to the closure"

### DIFF
--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -1,5 +1,8 @@
-( function ( $, rangy ) {
+( function ( $ ) {
 	'use strict';
+
+	// rangy is defined in the rangy library
+	/*global rangy */
 
 	/**
 	 * IME Class
@@ -715,4 +718,4 @@
 			return index;
 		} );
 	}
-}( jQuery, rangy ) );
+}( jQuery ) );


### PR DESCRIPTION
This reverts commit 67a0e53d4b159b276c8eb4201a440a604a6049ba.

Loading rangy in such a way doesn't work with the way
jquery.ime is loaded in the MediaWiki ULS extension.
The issue is reported as
https://github.com/wikimedia/jquery.ime/issues/266
