### PR TITLE
Official link of Standard Persian Keyboard

### DIFF
--- a/rules/fa/fa-kbd.js
+++ b/rules/fa/fa-kbd.js
@@ -6,7 +6,7 @@
 		name: 'kbd',
 		description: 'Persian standard (ISIRI 9147) keyboard layout',
 		date: '2013-08-30',
-		URL: 'http://behnam.esfahbod.info/standards/isiri-keyboard-9147.pdf',
+		URL: 'http://www.isiri.org/portal/files/std/9147.pdf',
 		author: 'Ebrahim Byagowi',
 		license: 'GPLv3',
 		version: '1.0',


### PR DESCRIPTION
This is official link of ISIRI 9147 keyboard.
