### PR TITLE
Change de-transliteration name to Deutsch Tilde

### DIFF
--- a/rules/de/de-transliteration.js
+++ b/rules/de/de-transliteration.js
@@ -3,7 +3,7 @@
 
 	var de = {
 		id: 'de-transliteration',
-		name: 'Deutsch',
+		name: 'Deutsch Tilde',
 		description: 'German input method',
 		date: '2012-11-20',
 		URL: 'http://github.com/wikimedia/jquery.ime',

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -237,7 +237,7 @@
 			source: 'rules/th/th-pattachote.js'
 		},
 		'de-transliteration': {
-			name: 'Deutsch',
+			name: 'Deutsch Tilde',
 			source: 'rules/de/de-transliteration.js'
 		},
 		'el-kbd': {


### PR DESCRIPTION
It was indicated[1] that the current name "Deutsch" is confusing.

[1] https://bugzilla.wikimedia.org/55698
