### PR TITLE
Gruntfile: load tasks from grunt-contrib-css*

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 module.exports = function ( grunt ) {
-	grunt.loadNpmTasks('grunt-css');
+	grunt.loadNpmTasks('grunt-contrib-cssmin');
+	grunt.loadNpmTasks('grunt-contrib-csslint');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-contrib-qunit');


### PR DESCRIPTION
Since grunt-css is deprecated and replaces by grunt-contrib-cssmin and
grunt-contrib-csslint.
