### PR TITLE
Apply /* @embed */ pragma to all images, not just the topmost in each block

### DIFF
--- a/css/jquery.ime.css
+++ b/css/jquery.ime.css
@@ -2,8 +2,11 @@
 	position: absolute;
 	/* @embed */
 	background: url('../images/ime-active.png') no-repeat left center;
+	/* @embed */
 	background-image: -webkit-linear-gradient(transparent, transparent), url('../images/ime-active.svg');
+	/* @embed */
 	background-image: -moz-linear-gradient(transparent, transparent), url('../images/ime-active.svg');
+	/* @embed */
 	background-image: linear-gradient(transparent, transparent), url('../images/ime-active.svg');
 	background-color: rgba(255,255,255,0.75);
 	background-position: left 3px center;
@@ -170,8 +173,11 @@ span.ime-disable-shortcut {
 .imeselector-menu .ime-checked {
 	/* @embed */
 	background: url(../images/tick.png) no-repeat left center;
+	/* @embed */
 	background-image: -webkit-linear-gradient(transparent, transparent), url('../images/tick.svg');
+	/* @embed */
 	background-image: -moz-linear-gradient(transparent, transparent), url('../images/tick.svg');
+	/* @embed */
 	background-image: linear-gradient(transparent, transparent), url('../images/tick.svg');
 	background-position: left 4px center;
 	background-position-x: 4px;


### PR DESCRIPTION
MediaWiki ResourceLoader's CSSMin scopes each /\* @embed */ to the rule
immediately below it, not the entire block. This patch adds the pragma for the
image assets which were omitted.
