### PR TITLE
"Use native keyboard" selected by default 

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -434,6 +434,7 @@
 					'class': 'ime-disable-link',
 					'data-i18n': 'jquery-ime-disable-text'
 				} )
+				.addClass( 'ime-checked' )
 				.text( 'System input method' )
 			).append( $( '<span>' )
 				.addClass( 'ime-disable-shortcut' )


### PR DESCRIPTION
For language with no input methods, "use native keyboard" is selected by default 
