### PR TITLE
Set 'checked' for Native Keyboard when no methods are available

### DIFF
--- a/src/jquery.ime.selector.js
+++ b/src/jquery.ime.selector.js
@@ -627,6 +627,7 @@
 					'class': 'ime-disable-link',
 					'data-i18n': 'jquery-ime-disable-text'
 				} )
+				.addClass( 'ime-checked' )
 				.text( 'System input method' ),
 			$( '<span>' )
 				.addClass( 'ime-disable-shortcut' )

--- a/test/jquery.ime.test.js
+++ b/test/jquery.ime.test.js
@@ -194,6 +194,11 @@
 		assert.strictEqual( textareaIME.getLanguage(), 'ru', 'Language changed after setting a valid value' );
 	} );
 
+	QUnit.test( 'Default input method for language without input methods test', 1, function ( assert ) {
+		$.ime.preferences.setLanguage( 'es' );
+		assert.strictEqual( $.ime.preferences.getIM(), 'system', 'Use native keyboard is selected by default' );
+	} );
+
 	function caretTest( text, start, end ) {
 		QUnit.test( 'Cursor positioning tests -' + text + '(' + start + ',' + end + ')' , 1, function ( assert ) {
 			var $ced = $( '<div contenteditable="true">' ),


### PR DESCRIPTION
For language with no input methods, "use native keyboard" is selected by default. Added test for it. 
Bug: 53695
