### PR TITLE
Add lud transliteration

### DIFF
--- a/rules/lud/lud-transliteration.js
+++ b/rules/lud/lud-transliteration.js
@@ -1,0 +1,29 @@
+( function ( $ ) {
+	'use strict';
+
+	var mapping = {
+		id: 'lud-transliteration',
+		name: 'lud',
+		description: 'Ludic transliteration',
+		date: '2014-06-14',
+		URL: 'http://github.com/wikimedia/jquery.ime',
+		author: 'Niklas Laxström',
+		license: 'MIT',
+		version: '1.0',
+		contextLength: 0,
+		maxKeyLength: 2,
+		patterns: [
+			['ch', 'č'],
+			['C[hH]', 'Č'],
+			['sh', 'š'],
+			['S[hH]', 'Š'],
+			['zh', 'ž'],
+			['Z[hH]', 'Ž'],
+			['y', 'ü'],
+			['Y', 'Ü'],
+			['\'', '’']
+		]
+	};
+
+	$.ime.register( mapping );
+}( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -158,6 +158,10 @@
 			name: 'translitterointi',
 			source: 'rules/fi/fi-transliteration.js'
 		},
+		'lud-transliteration': {
+			name: 'lud',
+			source: 'rules/lud/lud-transliteration.js'
+		},
 		'hi-transliteration': {
 			name: 'लिप्यंतरण',
 			source: 'rules/hi/hi-transliteration.js'
@@ -678,6 +682,10 @@
 		'fi': {
 			autonym: 'Suomi',
 			inputmethods: [ 'fi-transliteration' ]
+		},
+		'lud': {
+			autonym: 'lüüdi',
+			inputmethods: [ 'lud-transliteration' ]
 		},
 		'gom': {
 			autonym: 'कोंकणी',


### PR DESCRIPTION
Ludic alphabet is abcčdefghijklmnoprsšzžtuvüäö’ according to Lüüdilaine, 2013 (ISSN 1796-7384).

Wikipedia [claims](https://en.wikipedia.org/wiki/Ludic_language) Ludic uses [Karelian Alphabet](https://en.wikipedia.org/wiki/Karelian_alphabet#Current_Karelian_alphabet_.282007.E2.80.93.29) but the one presented there is different.
