### PR TITLE
Increase maxKeyLength to 5 for si-singlish

### DIFF
--- a/rules/si/si-singlish.js
+++ b/rules/si/si-singlish.js
@@ -11,7 +11,7 @@
 		license: 'GPLv3',
 		version: '1.0',
 		contextLength: 5,
-		maxKeyLength: 2,
+		maxKeyLength: 5,
 		patterns: [
 			//['ඬ්හ්a', 'ඳ'],	// nndha
 			['ඬ්h', 'ඳ්'], // nndh


### PR DESCRIPTION
Fixes issue #425 ('Cannot type "Sri Lanka" in Sinhala si-singlish')