### PR TITLE
Clean up devDependencies

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,28 +1,34 @@
 {
-	"predef": [
-		"jQuery",
-		"QUnit",
-		"rangy",
-		"_"
-	],
 
+	"globals": {
+		"QUnit": false,
+		"rangy": false,
+		"_": false
+	},
+
+	// Enforcing
+	"bitwise": true,
 	"curly": true,
 	"eqeqeq": true,
+	"freeze": true,
+	"latedef": "nofunc",
+	"futurehostile": true,
 	"immed": true,
-	"latedef": true,
 	"newcap": true,
 	"noarg": true,
-	"noempty": true,
 	"nonew": true,
-	"plusplus": false,
+	"noempty": true,
 	"quotmark": "single",
 	"undef": true,
 	"unused": true,
 	"strict": true,
-	"trailing": true,
+
+	// Relaxing
+	"plusplus": false,
 	"laxbreak": true,
+	"-W100": true,
+
+	// Environment
 	"browser": true,
-	"nomen": true,
-	"onevar": true,
-	"white": false
+	"jquery": true
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "Srikanth Lakshmanan <srik.lak@gmail.com>"
   ],
   "devDependencies": {
+    "grunt": "0.4.5",
     "grunt-contrib-csslint": "~0.1.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-copy": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,16 @@
   ],
   "devDependencies": {
     "grunt": "0.4.5",
-    "grunt-contrib-csslint": "~0.1.0",
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-copy": "~0.4.0",
-    "grunt-contrib-cssmin": "~0.4.0",
-    "grunt-contrib-qunit": "~0.2.0",
-    "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.1.2",
-    "grunt-cli": "~0.1.9"
+    "grunt-contrib-csslint": "1.0.0",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-copy": "1.0.0",
+    "grunt-contrib-cssmin": "1.0.1",
+    "grunt-contrib-qunit": "1.1.0",
+    "grunt-contrib-concat": "1.0.0",
+    "grunt-contrib-uglify": "1.0.1",
+    "grunt-cli": "1.1.0",
+    "jquery": "1.11.3",
+    "qunitjs": "1.22.0"
   },
   "repository": {
     "type": "git",

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,7 @@
 	<title>jQuery.ime Test Suite</title>
 
 	<!-- External libs -->
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js" ></script>
+	<script src="../node_modules/jquery/dist/jquery.js"></script>
 
 	<!-- Source of our libs -->
 	<script src="../libs/rangy/rangy-core.js"></script>
@@ -18,8 +18,8 @@
 	<script src="jquery.ime.test.fixtures.js"></script>
 
 	<!-- Test framework -->
-	<link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.14.0.css">
-	<script src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
+	<link rel=stylesheet href="../node_modules/qunitjs/qunit/qunit.css">
+	<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
 
 	<!-- Test config -->
 	<script>


### PR DESCRIPTION
Bring in grunt explicitly.

Bump all devDependencies to latest, and pin versions rather than using ~, following the practice we use elsewhere).

Bump .jshintrc to a more current version (though lots of this is using
outdated and soon-to-be-removed options); some of the already-removed
options have been dropped from it for now, but will require revisiting.

No need to load jQuery and Qunit over the Web when we can trivially
just add them as devDependencies (like we do elsewhere).