### PR TITLE
'ट्रन्स्लितेरतिओन्' change with लिप्यन्तरणम् for Sanskrit

### DIFF
--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -556,7 +556,7 @@
 			source: 'rules/sa/sa-inscript2.js'
 		},
 		'sa-transliteration': {
-			name: 'ट्रन्स्लितेरतिओन्',
+			name: 'लिप्यन्तरणम्',
 			source: 'rules/sa/sa-transliteration.js'
 		},
 		'sah-transliteration': {


### PR DESCRIPTION
लिप्यन्तरणम् It must be of  'ट्रन्स्लितेरतिओन्' it's place.