### PR TITLE
Corrected autonym for gom

### DIFF
--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -763,7 +763,7 @@
 			inputmethods: [ 'lud-transliteration' ]
 		},
 		gom: {
-			autonym: 'गोवा कोंकणी / Gova Konknni',
+			autonym: 'गोंयची कोंकणी / Gõychi Konknni',
 			inputmethods: [ 'hi-transliteration', 'hi-inscript', 'gom-inscript2' ]
 		},
 		gu: {


### PR DESCRIPTION
Corrected the local name for gom. https://phabricator.wikimedia.org/T137222