### PR TITLE
Changed extended patterns to concatenation

### DIFF
--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -150,15 +150,17 @@
 		transliterate: function ( input, context, altGr ) {
 			var patterns, regex, rule, replacement, i, retval;
 
+			patterns = this.inputmethod.patterns || [];
+
 			if ( altGr ) {
-				patterns = this.inputmethod.patterns_x || [];
-			} else {
-				patterns = this.inputmethod.patterns || [];
+				// if an alt key is pressed then give priority to patterns_x
+				// Example: AltGr+A where alt alter the keycode
+				patterns = ( this.inputmethod.patterns_x || [] )
+					.concat( patterns );
 			}
 
 			if ( this.shifted ) {
-				// if shift is pressed give priority for the patterns_shift
-				// if exists.
+				// if shift is pressed then give priority to patterns_shift
 				// Example: Shift+space where shift does not alter the keycode
 				patterns = ( this.inputmethod.patterns_shift || [] )
 					.concat( patterns );
@@ -206,11 +208,21 @@
 			if ( e.which === 16 ) { // shift key
 				this.shifted = false;
 			}
+			if ( e.which === 225 /* alt graphics key */
+				// || e.which === 224 /* alt key */
+				) {
+				this.altered = false;
+			}
 		},
 
 		keydown: function ( e ) {
 			if ( e.which === 16 ) { // shift key
 				this.shifted = true;
+			}
+			if ( e.which === 225 /* alt graphics key */
+				// || e.which === 224 /* alt key */
+				) {
+				this.altered = true;
 			}
 		},
 
@@ -221,7 +233,7 @@
 		 * @return {boolean}
 		 */
 		keypress: function ( e ) {
-			var altGr = false,
+			var altGr = this.altered,
 				c, input, replacement;
 
 			if ( !this.active ) {


### PR DESCRIPTION
This changes the behavior of the dependency loading, as it was earlier an override, and with this change it is an extension (or a concatenation).

During testing it became obvious that the previous solution simply did not work. Perhaps I did something obviously wrong, but I did check with other code. I even had to redo some of my own code that was obviously wrong.

I have not been able to verify if this change fails somewhere, it is only verified on a Ubu-box in Vagrant, and other OS and setup might handle the altGr-key somewhat different. During tests on that setup I only get errors from the usual suspects, no new errors. Still I am not convinced that the testing framework accurately reproduce a real browser when it comes to key events.

This change set replaces the somewhat messy #466.
