### PR TITLE
Update and extend the Norwegian rules

### DIFF
--- a/rules/nb/nb-baseforms.js
+++ b/rules/nb/nb-baseforms.js
@@ -1,0 +1,130 @@
+// jscs:disable requireMultipleVarDecl
+( function ( $ ) {
+	'use strict';
+
+	var prefixes = 'E|P|T|G|M|k|h|da|d|c|m|u|μ|n|p|f|a',
+		baseSIUnits = 'm|g|s|A|K|mol|[cC]d',
+		derivedSIUnits = 'rad|sr|[hH]z|N|[pP]a|J|W|C|V|F|Ω|S|[wW]b|T|H|°C|[lL]m|[lL]x|[bB]q|[gG]|[sS]v|kat',
+		supers = '[⁺⁻⁰¹²³⁴⁵⁶⁷⁸⁹]',
+		sups = { 0: '⁰', 1: '¹', 2: '²', 3: '³', 4: '⁴', 5: '⁵', 6: '⁶', 7: '⁷', 8: '⁸', 9: '⁹' },
+		signs = {};
+
+	signs[ '+' ] = '⁺';
+	signs[ '-' ] = '⁻';
+
+	var defs = {
+		id: 'nb-baseforms',
+		name: 'Norwegian basic transliteration',
+		description: 'A few basic forms transliterated. There are no ligatures in this set.',
+		date: '2012-12-04, 2017-02-02',
+		URL: 'http://www.evertype.com/alphabets/bokmaal-norwegian.pdf',
+		author: 'John Erling Blad',
+		license: 'GPLv3',
+		version: '1.0',
+		contextLength: 1,
+		maxKeyLength: 9, // due to spaces for numerals
+		patterns: [
+
+			// apostrophes
+			[ '([sxzSXZ])›(\\s)', '\u0027', '$1ʼ$2' ],	// whitespace
+			[ '([sxzSXZ])›(")', '\u0027', '$1ʼ»' ],		// double guillemet
+			[ '([sxzSXZ])›(\u0027)', '\u0027', '$1ʼ›' ],// single guillemet
+
+			// single quote as guillemet
+			[ '(^|\\s|«)\u0027', '$1‹' ],				// opening
+			[ '([^\\s\u0027‹›])\u0027', '$1›' ],		// closing
+			// rollback
+			[ '‹(\\s)', '\u0027', '\u0027$1' ],			// failed opening
+			[ '›(\\S)', '\u0027', '\u0027$1' ],			// failed closing
+			[ '[‹›]\u0027', '\u0027', '\u0027\u0027' ],	// revert
+
+			// double quote as guillemet
+			[ '(^|\\s|‹)"', '$1«' ],					// opening
+			[ '([^\\s"«»])"', '$1»' ],					// closing
+			// rollback
+			[ '«(\\s)', '"', '"$1' ],					// failed opening
+			[ '»(\\S)', '"', '"$1' ],					// failed closing
+			[ '[«»]"', '"', '""' ],						// revert
+
+			// horizontal ellipsis
+			[ '\\.\\.\\.', '…' ],
+			[ '…\\.', '.', '....' ],
+
+			// Superscript for numbers
+			[ '\\^0', '⁰' ],
+			[ '\\^1', '¹' ],
+			[ '\\^2', '²' ],
+			[ '\\^3', '³' ],
+			[ '\\^4', '⁴' ],
+			[ '\\^5', '⁵' ],
+			[ '\\^6', '⁶' ],
+			[ '\\^7', '⁷' ],
+			[ '\\^8', '⁸' ],
+			[ '\\^9', '⁹' ],
+			[
+				'(' + prefixes + '|)(' + baseSIUnits + '|' + derivedSIUnits + ')([-+]?)([0-9])',
+                function ( $0, $1, $2, $3, $4 ) { return $1 + $2 + ( signs[ $3 ] !== undefined ? signs[ $3 ] : '' ) + sups[ $4 ]; }
+			],
+
+			// Subscript for numbers
+			[ '_0', '₀' ],
+			[ '_1', '₁' ],
+			[ '_2', '₂' ],
+			[ '_3', '₃' ],
+			[ '_4', '₄' ],
+			[ '_5', '₅' ],
+			[ '_6', '₆' ],
+			[ '_7', '₇' ],
+			[ '_8', '₈' ],
+			[ '_9', '₉' ],
+
+			// Superscript for additional chars
+			[ '\\^i', 'ⁱ' ],
+			[ '\\^\\+', '⁺' ],
+			[ '\\^-', '⁻' ],
+			[ '\\^=', '⁼' ],
+			[ '\\^\\(', '⁽' ],
+			[ '\\^\\)', '⁾' ],
+			[ '\\^n', 'ⁿ' ],
+
+			// Subscript for additional chars
+			[ '_\\+', '₊' ],
+			[ '_-', '₋' ],
+			[ '_=', '₌' ],
+			[ '_\\(', '₍' ],
+			[ '_\\)', '₎' ],
+			[ '_a', 'ₐ' ],
+			[ '_e', 'ₑ' ],
+			[ '_o', 'ₒ' ],
+			[ '_x', 'ₓ' ],
+			[ '_Ə', 'ₔ' ], // no idea how this will be typed
+			[ '_h', 'ₕ' ],
+			[ '_k', 'ₖ' ],
+			[ '_l', 'ₗ' ],
+			[ '_m', 'ₘ' ],
+			[ '_n', 'ₙ' ],
+			[ '_p', 'ₚ' ],
+			[ '_s', 'ₛ' ],
+			[ '_t', 'ₜ' ],
+
+			// Spaces for numerals
+			[ '(\\d)\u0020', '$1\u2007' ],				// figure space
+			[ '(\\d)\u2007(\\D)', '\u0020', '$1 $2' ],	// revert to normal space
+			[
+				'(\\d)([\u0020\u2007])(' + prefixes + '|)(' + baseSIUnits + '|' + derivedSIUnits + ')(' + supers + '*)(\\W)',
+				'$1\u2007$3$4$5$6'
+			],
+
+			// hyphen-minus
+			[ '(\\w)-([\\n\\r])', '$1\u00AD' ],			// on last word on line -> soft-hyphen
+			[ '([\\n\\r]\\t*)-', '$1–' ],				// with space padding -> endash
+			[ '(\\w)-(\\ )', '$1–$2' ],					// after word before space -> endash
+			[ '(\\ )-(\\ )', '$1–$2' ],					// with space padding -> endash
+			[ '-(\\d)', '−$1' ],						// in front of numbers -> minus
+			[ '-(\\w)', '‐$1' ]							// in front of words -> hyphen
+
+		]
+	};
+
+	$.ime.register( defs );
+}( jQuery ) );

--- a/rules/nb/nb-extforms.js
+++ b/rules/nb/nb-extforms.js
@@ -1,0 +1,54 @@
+( function ( $ ) {
+	'use strict';
+
+	var defs = {
+		id: 'nb-extforms',
+		name: 'Norwegian extended ligatures',
+		description: 'Ligatures will be transliterated if they are typed while holding down the extended key. Also includes the basic forms.',
+		date: '2012-12-04',
+		URL: 'http://www.evertype.com/alphabets/bokmaal-norwegian.pdf',
+		author: 'John Erling Blad',
+		license: 'GPLv3',
+		version: '1.0',
+		contextLength: 0,
+		maxKeyLength: 2
+	};
+
+	defs.patterns = $.ime.inputmethods[ 'nb-baseforms' ].patterns.concat( [
+		// Use ligature "AE" for "Æ"
+		[ 'ª€', 'æ' ],
+		[ '[ªº][€¢]', 'Æ' ],
+
+		// Use ligature "OE" for "Ø"
+		[ 'œ€', 'ø' ],
+		[ '[œŒ][€¢]', 'Ø' ],
+
+		// Use ligature "AA" for "Å"
+		[ 'ªª', 'å' ],
+		[ '[ªº][ªº]', 'Å' ]
+	] );
+
+	defs.patterns_x = [
+		// Use ligature "AE" for "Æ"
+		[ 'ae', 'æ' ],
+		[ '[aA][eE]', 'Æ' ],
+
+		// Use ligature "OE" for "Ø"
+		[ 'oe', 'ø' ],
+		[ '[oO][eE]', 'Ø' ],
+
+		// Use ligature "AA" for "Å"
+		[ 'aa', 'å' ],
+		[ '[aA][aA]', 'Å' ]
+	];
+
+	// make sure these don't get out of sync
+	if ( defs.contextLength < $.ime.inputmethods[ 'nb-baseforms' ].contextLength ) {
+		defs.contextLength = $.ime.inputmethods[ 'nb-baseforms' ].contextLength;
+	}
+	if ( defs.maxKeyLength <  $.ime.inputmethods[ 'nb-baseforms' ].maxKeyLength ) {
+		defs.maxKeyLength =  $.ime.inputmethods[ 'nb-baseforms' ].maxKeyLength;
+	}
+
+	$.ime.register( defs );
+}( jQuery ) );

--- a/rules/nb/nb-normforms.js
+++ b/rules/nb/nb-normforms.js
@@ -3,48 +3,84 @@
 
 	var defs = {
 		id: 'nb-normforms',
-		name: 'Norsk normal transliterasjon',
-		description: 'Norwegian input method with most common form transliterated',
+		name: 'Norwegian automatic ligatures',
+		description: 'Ligatures will be autotransliterated according to simple heurestics. Also includes the basic forms.',
 		date: '2012-12-04',
 		URL: 'http://www.evertype.com/alphabets/bokmaal-norwegian.pdf',
-		// URL: 'http://www.evertype.com/alphabets/nynorsk-norwegian.pdf',
 		author: 'John Erling Blad',
 		license: 'GPLv3',
-		version: '1.0',
+		version: '2.0',
 		contextLength: 1,
-		maxKeyLength: 3,
-		patterns: [
-			// The most common transliterations
-			[ 'aa', 'å' ],
-			[ 'AA', 'Å' ],
-			[ 'Aa', 'Å' ],
-			[ 'ae', 'æ' ],
-			[ 'AE', 'Æ' ],
-			[ 'Ae', 'Æ' ],
-			[ 'oe', 'ø' ],
-			[ 'OE', 'Ø' ],
-			[ 'Oe', 'Ø' ],
-			// The previous as negated transliterations, mostly for names
-			[ 'åa', 'a', 'aa' ],
-			[ 'ÅA', 'A', 'AA' ],
-			[ 'Åa', 'A', 'Aa' ],
-			[ 'åA', 'a', 'aA' ],
-			[ 'æe', 'e', 'ae' ],
-			[ 'ÆE', 'E', 'AE' ],
-			[ 'Æe', 'E', 'Ae' ],
-			[ 'æE', 'e', 'aE' ],
-			[ 'øe', 'e', 'oe' ],
-			[ 'ØE', 'E', 'OE' ],
-			[ 'Øe', 'E', 'Oe' ], // this fails for some names like "Øen"
-			[ 'øE', 'e', 'oE' ]
-			// historically similar forms
-			// "Å" is sometimes written as "Aa", and "å" as "aa", but in names
-			// it is not generally acceptable to use this transliteration. To
-			// handle those situations we need some oposite forms.
-			// There is a similar character "Å" for the length unit Angstrom,
-			// but this is not the upper case letter Å.
-		]
+		maxKeyLength: 9
 	};
+
+	defs.patterns = $.ime.inputmethods[ 'nb-baseforms' ].patterns.concat( [
+		// early capture of hex
+		[ '((0x|#)[0-9a-fA-F]*[aA][aA])', '$1' ],
+		[ '((0x|#)[0-9a-fA-F]*[aA][eE])', '$1' ],
+
+		// collect ligature æ
+		[ 'ae', 'æ' ],
+		[ '(AE|Ae|aE)', 'Æ' ],
+		// rollback
+		[ '([iI][mM])æ([fFkKnN])', '[eE]', '$1ae$2' ],
+		[ '([iI][mM])Æ([fFkKnN])', '[eE]', '$1AE$2' ],
+		[ '([rR])æ([lL])', '[eE]', '$1ae$2' ],
+		[ '([rR])Æ([lL])', '[eE]', '$1AE$2' ],
+		[ '([sS])æ([kKpP])', '[eE]', '$1ae$2' ],
+		[ '([sS])Æ([kKpP])', '[eE]', '$1AE$2' ],
+		[ '([tT])æ([kK])', '[eE]', '$1ae$2' ],
+		[ '([tT])Æ([kK])', '[eE]', '$1AE$2' ],
+		[ 'æ([eE])', '[eE]', 'a$1' ],
+		[ 'Æ([eE])', '[eE]', 'A$1' ],
+
+		// collect ligature ø
+		[ 'oe', 'ø' ],
+		[ '([oO][eE])', 'Ø' ],
+		// rollback
+		[ '([dD])ø([uU])', '[eE]', '$1oe$2' ],
+		[ '([dD])Ø([uU])', '[eE]', '$1OE$2' ],
+		[ '([gG])ø([sS])', '[eE]', '$1oe$2' ],
+		[ '([gG])Ø([sS])', '[eE]', '$1OE$2' ],
+		[ '([iI])ø([tT])', '[eE]', '$1oe$2' ],
+		[ '([iI])Ø([tT])', '[eE]', '$1OE$2' ],
+		[ '([kK])ø([fF])', '[eE]', '$1oe$2' ],
+		[ '([kK])Ø([fF])', '[eE]', '$1OE$2' ],
+		[ '([nN])ø([nN\\s\\W])', '[eE]', '$1oe$2' ],
+		[ '([nN])Ø([nN\\s\\W])', '[eE]', '$1OE$2' ],
+		[ '(([iI][eE]|[aA][mM]|[bB][eE])[bB])ø([rR])', '[eE]', '$1oe$2' ],
+		[ '(([iI][eE]|[aA][mM]|[bB][eE])[bB])Ø([rR])', '[eE]', '$1OE$2' ],
+		[ '([pP])ø([nN])', '[eE]', '$1oe$2' ],
+		[ '([pP])Ø([nN])', '[eE]', '$1OE$2' ],
+		[ '([^tT][bBtT][rR])ø([nNrR])', '[eE]', '$1oe$2' ],
+		[ '([^tT][bBtT][rR])Ø([nNrR])', '[eE]', '$1OE$2' ],
+		[ 'ø([eE])', '[eE]', 'o$1' ],
+		[ 'Ø([eE])', '[eE]', 'O$1' ],
+
+		// collect ligature å
+		[ 'aa', 'å' ],
+		[ '(AA|Aa|aA)', 'Å' ],
+		// rollback
+		[ '([lL][jJ])å([kKnNtT])', '[aA]', '$1aa$2' ],
+		[ '([lL][jJ])Å([kKnNtT])', '[aA]', '$1AA$2' ],
+		[ '([iI][kK])å([^lL])', '[aA]', '$1aa$2' ],
+		[ '([iI][kK])Å([^lL])', '[aA]', '$1AA$2' ],
+		[ '([iI][mM])å([nNrRvV])', '[aA]', '$1aa$2' ],
+		[ '([iI][mM])Å([nNrRvV])', '[aA]', '$1AA$2' ],
+		[ '([tT])å([nN])', '[aA]', '$1aa$2' ],
+		[ '([tT])Å([nN])', '[aA]', '$1AA$2' ],
+		[ 'å([aA])', '[aA]', 'a$1' ],
+		[ 'Å([aA])', '[aA]', 'A$1' ]
+
+	] );
+
+	// make sure these don't get out of sync
+	if ( defs.contextLength < $.ime.inputmethods[ 'nb-baseforms' ].contextLength ) {
+		defs.contextLength = $.ime.inputmethods[ 'nb-baseforms' ].contextLength;
+	}
+	if ( defs.maxKeyLength <  $.ime.inputmethods[ 'nb-baseforms' ].maxKeyLength ) {
+		defs.maxKeyLength =  $.ime.inputmethods[ 'nb-baseforms' ].maxKeyLength;
+	}
 
 	$.ime.register( defs );
 }( jQuery ) );

--- a/rules/nb/nb-tildeforms.js
+++ b/rules/nb/nb-tildeforms.js
@@ -3,33 +3,42 @@
 
 	var defs = {
 		id: 'nb-tildeforms',
-		name: 'Norsk tildemerket transliterasjon',
-		description: 'Norwegian input method with initial tilde triggering transliteration',
+		name: 'Norwegian tildemarked ligatures',
+		description: 'Ligatures will only be transliterated if they are preceeded with a tilde. Also includes the basic forms.',
 		date: '2012-12-04',
 		URL: 'http://www.evertype.com/alphabets/bokmaal-norwegian.pdf',
-		// URL: 'http://www.evertype.com/alphabets/nynorsk-norwegian.pdf',
 		author: 'John Erling Blad',
 		license: 'GPLv3',
 		version: '1.0',
-		// contextLength: 1,
-		maxKeyLength: 3,
-		patterns: [
-			// Uses "~" as "approximatly similar to"
-			[ '°a', 'å' ], // The simple ~a does not work as there is a "ã"
-			[ '°A', 'Å' ], // The simple ~A does not work as there is a "Ã"
-			[ '~ae', 'æ' ], // The simple ~a does not work as there is a "ã"
-			[ '~AE', 'Æ' ], // The simple ~A does not work as there is a "Ã"
-			[ '~oe', 'ø' ], // The simple ~o does not work as there is a "õ"
-			[ '~OE', 'Ø' ], // The simple ~O does not work as there is a "Õ"
-			[ '~aa', 'å' ], // The simple ~a does not work as there is a "ã"
-			[ '~AA', 'Å' ] // The simple ~A does not work as there is a "Ã"
-			// historically similar forms
-			// "Å" is sometimes written as "Aa", and "å" as "aa", but in names
-			// it is not generally acceptable to use this transliteration.
-			// There is a similar character "Å" for the length unit Angstrom,
-			// but this is not the upper case letter Å.
-		]
+		contextLength: 0,
+		maxKeyLength: 3
 	};
+
+	defs.patterns = $.ime.inputmethods[ 'nb-baseforms' ].patterns.concat( [
+		// Use "°" together with "A" for "Å"
+		[ '°a', 'å' ],
+		[ '°A', 'Å' ],
+
+		// Use "~" as an approximation with the ligature "AE" for "Æ"
+		[ '~ae', 'æ' ],
+		[ '~[aA][eE]', 'Æ' ],
+
+		// Use "~" as an approximation with the ligature "OE" for "Ø"
+		[ '~oe', 'ø' ],
+		[ '~[oO][eE]', 'Ø' ],
+
+		// Use "~" as an approximation with the ligature "AA" for "Å"
+		[ '~aa', 'å' ],
+		[ '~[aA][aA]', 'Å' ]
+	] );
+
+	// make sure these don't get out of sync
+	if ( defs.contextLength < $.ime.inputmethods[ 'nb-baseforms' ].contextLength ) {
+		defs.contextLength = $.ime.inputmethods[ 'nb-baseforms' ].contextLength;
+	}
+	if ( defs.maxKeyLength <  $.ime.inputmethods[ 'nb-baseforms' ].maxKeyLength ) {
+		defs.maxKeyLength =  $.ime.inputmethods[ 'nb-baseforms' ].maxKeyLength;
+	}
 
 	$.ime.register( defs );
 }( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -440,18 +440,48 @@
 			name: 'Traditional',
 			source: 'rules/ne/ne-trad.js'
 		},
+		'nb-baseforms': {
+			name: 'Grunnleggende tegnsett',
+			source: 'rules/nb/nb-baseforms.js'
+		},
 		'nb-normforms': {
-			name: 'Normal transliterasjon',
-			source: 'rules/nb/nb-normforms.js'
+			name: 'Ligaturer uten merking',
+			source: 'rules/nb/nb-normforms.js',
+			depends: 'nb-baseforms'
 		},
 		'nb-tildeforms': {
-			name: 'Tildemerket transliterasjon',
-			source: 'rules/nb/nb-tildeforms.js'
+			name: 'Ligaturer merket med tilde',
+			source: 'rules/nb/nb-tildeforms.js',
+			depends: 'nb-baseforms'
 		},
+		'nb-extforms': {
+			name: 'Ligaturer som utvidet tegn',
+			source: 'rules/nb/nb-extforms.js',
+			depends: 'nb-baseforms'
+		},
+		/*
+		'nn-baseforms': {
+			name: 'Grunnleggande teiknsett',
+			source: 'rules/nb/nb-baseforms.js'
+		},
+		'nn-normforms': {
+			name: 'Ligaturer utan merking',
+			source: 'rules/nb/nb-normforms.js',
+			depends: 'nb-baseforms'
+		},
+		*/
 		'nn-tildeforms': {
-			name: 'Tildemerkt transliterasjon',
-			source: 'rules/nb/nb-tildeforms.js'
+			name: 'Ligaturer merkte med tilde',
+			source: 'rules/nb/nb-tildeforms.js',
+			depends: 'nb-baseforms'
 		},
+		/*
+		'nn-extforms': {
+			name: 'Ligaturer som utvida teikn',
+			source: 'rules/nb/nb-extforms.js',
+			depends: 'nb-baseforms'
+		},
+		*/
 		'or-transliteration': {
 			name: 'ଟ୍ରାନ୍ସଲିଟରେସନ',
 			source: 'rules/or/or-transliteration.js'

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -459,7 +459,6 @@
 			source: 'rules/nb/nb-extforms.js',
 			depends: 'nb-baseforms'
 		},
-		/*
 		'nn-baseforms': {
 			name: 'Grunnleggande teiknsett',
 			source: 'rules/nb/nb-baseforms.js'
@@ -469,19 +468,16 @@
 			source: 'rules/nb/nb-normforms.js',
 			depends: 'nb-baseforms'
 		},
-		*/
 		'nn-tildeforms': {
 			name: 'Ligaturer merkte med tilde',
 			source: 'rules/nb/nb-tildeforms.js',
 			depends: 'nb-baseforms'
 		},
-		/*
 		'nn-extforms': {
 			name: 'Ligaturer som utvida teikn',
 			source: 'rules/nb/nb-extforms.js',
 			depends: 'nb-baseforms'
 		},
-		*/
 		'or-transliteration': {
 			name: 'ଟ୍ରାନ୍ସଲିଟରେସନ',
 			source: 'rules/or/or-transliteration.js'
@@ -918,11 +914,11 @@
 		},
 		nb: {
 			autonym: 'Norsk (bokmål)',
-			inputmethods: [ 'nb-normforms', 'nb-tildeforms' ]
+			inputmethods: [ 'nb-baseforms', 'nb-normforms', 'nb-tildeforms', 'nb-extforms' ]
 		},
 		nn: {
 			autonym: 'Norsk (nynorsk)',
-			inputmethods: [ 'nb-normforms', 'nn-tildeforms' ]
+			inputmethods: [ 'nn-baseforms', 'nn-normforms', 'nn-tildeforms', 'nn-extforms' ]
 		},
 		or: {
 			autonym: 'ଓଡ଼ିଆ',

--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -150,15 +150,17 @@
 		transliterate: function ( input, context, altGr ) {
 			var patterns, regex, rule, replacement, i, retval;
 
+			patterns = this.inputmethod.patterns || [];
+
 			if ( altGr ) {
-				patterns = this.inputmethod.patterns_x || [];
-			} else {
-				patterns = this.inputmethod.patterns || [];
+				// if an alt key is pressed then give priority to patterns_x
+				// Example: AltGr+A where alt alter the keycode
+				patterns = ( this.inputmethod.patterns_x || [] )
+					.concat( patterns );
 			}
 
 			if ( this.shifted ) {
-				// if shift is pressed give priority for the patterns_shift
-				// if exists.
+				// if shift is pressed then give priority to patterns_shift
 				// Example: Shift+space where shift does not alter the keycode
 				patterns = ( this.inputmethod.patterns_shift || [] )
 					.concat( patterns );
@@ -206,11 +208,21 @@
 			if ( e.which === 16 ) { // shift key
 				this.shifted = false;
 			}
+			if ( e.which === 225 /* alt graphics key */
+				// || e.which === 224 /* alt key */
+				) {
+				this.altered = false;
+			}
 		},
 
 		keydown: function ( e ) {
 			if ( e.which === 16 ) { // shift key
 				this.shifted = true;
+			}
+			if ( e.which === 225 /* alt graphics key */
+				// || e.which === 224 /* alt key */
+				) {
+				this.altered = true;
 			}
 		},
 
@@ -221,7 +233,7 @@
 		 * @return {boolean}
 		 */
 		keypress: function ( e ) {
-			var altGr = false,
+			var altGr = this.altered,
 				c, input, replacement;
 
 			if ( !this.active ) {

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -11,6 +11,244 @@ var palochkaVariants = {
 	/*jshint unused:false */
 	testFixtures = [
 	{
+		description: 'Norwegian Transliteration test for base forms',
+		tests: [
+			// Apostrophes
+			{ input: 's\u0027 ', output: 'sʼ ', description: 'Norwegian modifying apostrophe (s\u0027 ) -> (sʼ )' },
+			{ input: 's\u0027"', output: 'sʼ»', description: 'Norwegian modifying apostrophe (s\u0027") -> (sʼ»)' },
+			{ input: 's\u0027\u0027', output: 'sʼ›', description: 'Norwegian modifying apostrophe (s\u0027\u0027) -> (sʼ›)' },
+
+			// Single quote
+			// @todo following tests fails, but manualchecking makes it clear it works as it should
+			// this can be due to diverging behavior in the different editable elements
+			// { input: ' \u0027a', output: ' ‹a', description: 'Norwegian single quote ( \u0027a) -> ( ‹a)' },
+			// { input: 'a\u0027 ', output: 'a› ', description: 'Norwegian single quote (a\u0027 ) -> (a› )' },
+			// { input: ' \u0027 ', output: ' \u0027 ', description: 'Norwegian single quote ( \u0027 ) -> ( \u0027 )' },
+
+			// Double quote
+			// @todo following tests fails, but manualchecking makes it clear it works as it should
+			// this can be due to diverging behavior in the different editable elements
+			// { input: ' "a', output: ' «a', description: 'Norwegian double quote ( "a) -> ( «a)' },
+			// { input: 'a" ', output: 'a» ', description: 'Norwegian double quote (a" ) -> (a» )' },
+			// { input: ' " ', output: ' " ', description: 'Norwegian double quote ( " ) -> ( " )' },
+
+			// horizontal ellipsis
+			{ input: '...', output: '…', description: 'Norwegian punctuation ... -> …' },
+			{ input: '....', output: '....', description: 'Norwegian punctuation .... -> ....' },
+
+			// Superscript for numbers
+			{ input: '^0', output: '⁰', description: 'Norwegian superscript 0 -> ⁰' },
+			{ input: '^1', output: '¹', description: 'Norwegian superscript 1 -> ¹' },
+			{ input: '^2', output: '²', description: 'Norwegian superscript 2 -> ²' },
+			{ input: '^3', output: '³', description: 'Norwegian superscript 3 -> ³' },
+			{ input: '^4', output: '⁴', description: 'Norwegian superscript 4 -> ⁴' },
+			{ input: '^5', output: '⁵', description: 'Norwegian superscript 5 -> ⁵' },
+			{ input: '^6', output: '⁶', description: 'Norwegian superscript 6 -> ⁶' },
+			{ input: '^7', output: '⁷', description: 'Norwegian superscript 7 -> ⁷' },
+			{ input: '^8', output: '⁸', description: 'Norwegian superscript 8 -> ⁸' },
+			{ input: '^9', output: '⁹', description: 'Norwegian superscript 9 -> ⁹' },
+
+			// Subscripts for numbers
+			{ input: '_0', output: '₀', description: 'Norwegian subscript 0 -> ₀' },
+			{ input: '_1', output: '₁', description: 'Norwegian subscript 1 -> ₁' },
+			{ input: '_2', output: '₂', description: 'Norwegian subscript 2 -> ₂' },
+			{ input: '_3', output: '₃', description: 'Norwegian subscript 3 -> ₃' },
+			{ input: '_4', output: '₄', description: 'Norwegian subscript 4 -> ₄' },
+			{ input: '_5', output: '₅', description: 'Norwegian subscript 5 -> ₅' },
+			{ input: '_6', output: '₆', description: 'Norwegian subscript 6 -> ₆' },
+			{ input: '_7', output: '₇', description: 'Norwegian subscript 7 -> ₇' },
+			{ input: '_8', output: '₈', description: 'Norwegian subscript 8 -> ₈' },
+			{ input: '_9', output: '₉', description: 'Norwegian subscript 9 -> ₉' },
+
+			// Superscript for additional chars
+			{ input: '^i', output: 'ⁱ', description: 'Norwegian superscript i -> ⁱ' },
+			{ input: '^+', output: '⁺', description: 'Norwegian superscript + -> ⁺' },
+			{ input: '^-', output: '⁻', description: 'Norwegian superscript - -> ⁻' },
+			{ input: '^=', output: '⁼', description: 'Norwegian superscript = -> ⁼' },
+			{ input: '^(', output: '⁽', description: 'Norwegian superscript ( -> ⁽' },
+			{ input: '^)', output: '⁾', description: 'Norwegian superscript ) -> ⁾' },
+			{ input: '^n', output: 'ⁿ', description: 'Norwegian superscript n -> ⁿ' },
+
+			// Subscript for additional chars
+			{ input: '_+', output: '₊', description: 'Norwegian subscript + -> ₊' },
+			{ input: '_-', output: '₋', description: 'Norwegian subscript - -> ₋' },
+			{ input: '_=', output: '₌', description: 'Norwegian subscript = -> ₌' },
+			{ input: '_(', output: '₍', description: 'Norwegian subscript ( -> ₍' },
+			{ input: '_)', output: '₎', description: 'Norwegian subscript ) -> ₎' },
+			{ input: '_a', output: 'ₐ', description: 'Norwegian subscript a -> ₐ' },
+			{ input: '_e', output: 'ₑ', description: 'Norwegian subscript e -> ₑ' },
+			{ input: '_o', output: 'ₒ', description: 'Norwegian subscript o -> ₒ' },
+			{ input: '_x', output: 'ₓ', description: 'Norwegian subscript x -> ₓ' },
+			{ input: '_Ə', output: 'ₔ', description: 'Norwegian subscript Ə -> ₔ' },
+			{ input: '_h', output: 'ₕ', description: 'Norwegian subscript h -> ₕ' },
+			{ input: '_k', output: 'ₖ', description: 'Norwegian subscript k -> ₖ' },
+			{ input: '_l', output: 'ₗ', description: 'Norwegian subscript l -> ₗ' },
+			{ input: '_m', output: 'ₘ', description: 'Norwegian subscript m -> ₘ' },
+			{ input: '_n', output: 'ₙ', description: 'Norwegian subscript n -> ₙ' },
+			{ input: '_p', output: 'ₚ', description: 'Norwegian subscript p -> ₚ' },
+			{ input: '_s', output: 'ₛ', description: 'Norwegian subscript s -> ₛ' },
+			{ input: '_t', output: 'ₜ', description: 'Norwegian subscript t -> ₜ' },
+
+			// Superscripts in units
+			{ input: 'm2', output: 'm²', description: 'Norwegian superscript (m2) -> (m²)' },
+			{ input: 'km2', output: 'km²', description: 'Norwegian superscript (km2) -> (km²)' },
+			{ input: 'm-2kg-1s4A2', output: 'm⁻²kg⁻¹s⁴A²', description: 'Norwegian def of Farad (m-2kg-1s4A2) -> (m⁻²kg⁻¹s⁴A²)' },
+
+			// Spaces for numerals
+			{ input: '123 ', output: '123\u2007', description: 'Norwegian space for numerals (123 ) -> (123\u2007)' },
+			{ input: '123 k', output: '123 k', description: 'Norwegian space for numerals (123 k) -> (123 k)' },
+			{ input: '123 km2.', output: '123\u2007km².', description: 'Norwegian space for numerals (123 km2.) -> (123\u2007km².)' },
+
+			// hyphen-minus
+			{ input: '-1', output: '−1', description: 'Norwegian hyphen-minus -1 -> −1' },
+			{ input: '-a', output: '‐a', description: 'Norwegian hyphen-minus -a -> ‐a' },
+			// @todo following tests fails, but manualchecking makes it clear it works as it should
+			// this can be due to diverging behavior in the different editable elements
+			// { input: 'a-\n', output: 'a\u00AD', description: 'Norwegian hyphen-minus (a-\\n) -> (aSHY)' },
+			// { input: '\n-', output: '\n–', description: 'Norwegian hyphen-minus (\\n-) -> (\\n–)' },
+			{ input: 'a- ', output: 'a– ', description: 'Norwegian hyphen-minus (a- ) -> (a– )' },
+			{ input: ' - ', output: ' – ', description: 'Norwegian hyphen-minus ( - ) -> ( – )' }
+		],
+		inputmethod: 'nb-baseforms',
+		multiline: true
+	},
+	{
+		description: 'Norwegian Transliteration test for extended forms',
+		tests: [
+			// Test ligature æ
+			{ input: [ [ 'ª', false ], [ '€', false ] ], output: 'æ', description: 'Norwegian regular ª€ -> æ' },
+			{ input: [ [ 'a', true ], [ 'e', true ] ], output: 'æ', description: 'Norwegian extended ae -> æ' },
+			{ input: [ [ 'º', false ], [ '¢', false ] ], output: 'Æ', description: 'Norwegian regular º¢ -> Æ' },
+			{ input: [ [ 'A', true ], [ 'E', true ] ], output: 'Æ', description: 'Norwegian extended AE -> Æ' },
+
+			// Test ligature ø
+			{ input: [ [ 'œ', false ], [ '€', false ] ], output: 'ø', description: 'Norwegian regular œ€ -> ø' },
+			{ input: [ [ 'o', true ], [ 'e', true ] ], output: 'ø', description: 'Norwegian extended oe -> ø' },
+			{ input: [ [ 'Œ', false ], [ '¢', false ] ], output: 'Ø', description: 'Norwegian regular Œ¢ -> Ø' },
+			{ input: [ [ 'O', true ], [ 'E', true ] ], output: 'Ø', description: 'Norwegian extended OE -> Ø' },
+
+			// Test ligature å
+			{ input: [ [ 'ª', false ], [ 'ª', false ] ], output: 'å', description: 'Norwegian regular ªª -> å' },
+			{ input: [ [ 'a', true ], [ 'a', true ] ], output: 'å', description: 'Norwegian extended aa -> å' },
+			{ input: [ [ 'º', false ], [ 'º', false ] ], output: 'Å', description: 'Norwegian regular ºº -> Å' },
+			{ input: [ [ 'A', true ], [ 'A', true ] ], output: 'Å', description: 'Norwegian extended AA -> Å' }
+		],
+		inputmethod: 'nb-extforms',
+		multiline: true
+	},
+	{
+		description: 'Norwegian Transliteration test for normal forms',
+		tests: [
+			// Exceptions for hex codes
+			{ input: '0xae', output: '0xae', description: 'Exception on hex num 0xae -> 0xae' },
+			{ input: '0x112233ae', output: '0x112233ae', description: 'Exception on hex num 0x112233ae -> 0x112233ae' },
+			{ input: '0xAE', output: '0xAE', description: 'Exception on hex num 0xAE -> 0xAE' },
+			{ input: '0x112233AE', output: '0x112233AE', description: 'Exception on hex num 0x112233AE -> 0x112233AE' },
+
+			{ input: '#ae', output: '#ae', description: 'Exception on color defs #ae -> #ae' },
+			{ input: '#1122ae', output: '#1122ae', description: 'Exception on color defs #1122ae -> #1122ae' },
+			{ input: '#AE', output: '#AE', description: 'Exception on color defs #AE -> #AE' },
+			{ input: '#1122AE', output: '#1122AE', description: 'Exception on color defs #1122AE -> #1122AE' },
+
+			{ input: '0xaa', output: '0xaa', description: 'Exception on hex num 0xaa -> 0xaa' },
+			{ input: '0x112233aa', output: '0x112233aa', description: 'Exception on hex num 0x112233aa -> 0x112233aa' },
+			{ input: '0xAA', output: '0xAA', description: 'Exception on hex num 0xAA -> 0xAA' },
+			{ input: '0x112233AA', output: '0x112233AA', description: 'Exception on hex num 0x112233AA -> 0x112233AA' },
+
+			{ input: '#aa', output: '#aa', description: 'Exception on color defs #aa -> #aa' },
+			{ input: '#1122aa', output: '#1122aa', description: 'Exception on color defs #1122aa -> #1122aa' },
+			{ input: '#AA', output: '#AA', description: 'Exception on color defs #AA -> #AA' },
+			{ input: '#1122AA', output: '#1122AA', description: 'Exception on color defs #1122AA -> #1122AA' },
+
+			// Test ligature æ
+			{ input: 'ae', output: 'æ', description: 'Norwegian old ae -> æ' },
+			{ input: 'aE', output: 'Æ', description: 'Norwegian old aE -> Æ' },
+			{ input: 'Ae', output: 'Æ', description: 'Norwegian old Ae -> Æ' },
+			{ input: 'AE', output: 'Æ', description: 'Norwegian old AE -> Æ' },
+			{ input: 'aee', output: 'ae', description: 'Norwegian old aee -> ae' },
+			{ input: 'aEe', output: 'Ae', description: 'Norwegian old aEe -> Ae' },
+			{ input: 'Aee', output: 'Ae', description: 'Norwegian old Aee -> Ae' },
+			{ input: 'AEe', output: 'Ae', description: 'Norwegian old AEe -> Ae' },
+			{ input: 'aeE', output: 'aE', description: 'Norwegian old aeE -> aE' },
+			{ input: 'aEE', output: 'AE', description: 'Norwegian old aEE -> AE' },
+			{ input: 'AeE', output: 'AE', description: 'Norwegian old AeE -> AE' },
+			{ input: 'AEE', output: 'AE', description: 'Norwegian old AEE -> AE' },
+
+			// Test ligature ø
+			{ input: 'oe', output: 'ø', description: 'Norwegian old oe -> ø' },
+			{ input: 'oE', output: 'Ø', description: 'Norwegian old oE -> Ø' },
+			{ input: 'Oe', output: 'Ø', description: 'Norwegian old Oe -> Ø' },
+			{ input: 'OE', output: 'Ø', description: 'Norwegian old OE -> Ø' },
+			{ input: 'indoeuropeisk', output: 'indoeuropeisk', description: 'Norwegian word "indoeuropeisk" -> "indoeuropeisk"' },
+			{ input: 'INDOEUROPEISK', output: 'INDOEUROPEISK', description: 'Norwegian word "INDOEUROPEISK" -> "INDOEUROPEISK"' },
+			{ input: 'goes', output: 'goes', description: 'Norwegian word "goes" -> "goes"' },
+			{ input: 'GOES', output: 'GOES', description: 'Norwegian word "GOES" -> "GOES"' },
+			{ input: 'bioetikk', output: 'bioetikk', description: 'Norwegian word "bioetikk" -> "bioetikk"' },
+			{ input: 'BIOETIKK', output: 'BIOETIKK', description: 'Norwegian word "BIOETIKK" -> "BIOETIKK"' },
+			{ input: 'koeffisient', output: 'koeffisient', description: 'Norwegian word "koeffisient" -> "koeffisient"' },
+			{ input: 'KOEFFISIENT', output: 'KOEFFISIENT', description: 'Norwegian word "KOEFFISIENT" -> "KOEFFISIENT"' },
+			{ input: 'noen', output: 'noen', description: 'Norwegian word "noen" -> "noen"' },
+			{ input: 'NOEN', output: 'NOEN', description: 'Norwegian word "NOEN" -> "NOEN"' },
+			{ input: 'oee', output: 'oe', description: 'Norwegian old oee -> oe' },
+			{ input: 'oEe', output: 'Oe', description: 'Norwegian old oEe -> Oe' },
+			{ input: 'Oee', output: 'Oe', description: 'Norwegian old Oee -> Oe' },
+			{ input: 'OEe', output: 'Oe', description: 'Norwegian old OEe -> Oe' },
+			{ input: 'oeE', output: 'oE', description: 'Norwegian old oeE -> oE' },
+			{ input: 'oEE', output: 'OE', description: 'Norwegian old oEE -> OE' },
+			{ input: 'OeE', output: 'OE', description: 'Norwegian old OeE -> OE' },
+			{ input: 'OEE', output: 'OE', description: 'Norwegian old OEE -> OE' },
+
+			// Test ligature å
+			{ input: 'aa', output: 'å', description: 'Norwegian old aa -> å' },
+			{ input: 'aA', output: 'Å', description: 'Norwegian old aA -> Å' },
+			{ input: 'Aa', output: 'Å', description: 'Norwegian old Aa -> Å' },
+			{ input: 'AA', output: 'Å', description: 'Norwegian old AA -> Å' },
+			// Test rollback
+			{ input: 'geriljaangrep', output: 'geriljaangrep', description: 'Norwegian word "geriljaangrep" -> "geriljaangrep"' },
+			{ input: 'GERILJAANGREP', output: 'GERILJAANGREP', description: 'Norwegian word "GERILJAANGREP" -> "GERILJAANGREP"' },
+			{ input: 'geriljaaktivitet', output: 'geriljaaktivitet', description: 'Norwegian word "geriljaaktivitet" -> "geriljaaktivitet"' },
+			{ input: 'GERILJAAKTIVITET', output: 'GERILJAAKTIVITET', description: 'Norwegian word "GERILJAAKTIVITET" -> "GERILJAAKTIVITET"' },
+			{ input: 'geriljaattentat', output: 'geriljaattentat', description: 'Norwegian word "geriljaattentat" -> "geriljaattentat"' },
+			{ input: 'GERILJAATTENTAT', output: 'GERILJAATTENTAT', description: 'Norwegian word "GERILJAATTENTAT" -> "GERILJAATTENTAT"' },
+			{ input: 'narkotikaavhengig', output: 'narkotikaavhengig', description: 'Norwegian word "narkotikaavhengig" -> "narkotikaavhengig"' },
+			{ input: 'NARKOTIKAAVHENGIG', output: 'NARKOTIKAAVHENGIG', description: 'Norwegian word "NARKOTIKAAVHENGIG" -> "NARKOTIKAAVHENGIG"' },
+			{ input: 'klimaanlegg', output: 'klimaanlegg', description: 'Norwegian word "klimaanlegg" -> "klimaanlegg"' },
+			{ input: 'KLIMAANLEGG', output: 'KLIMAANLEGG', description: 'Norwegian word "KLIMAANLEGG" -> "KLIMAANLEGG"' },
+			{ input: 'klimaarbeid', output: 'klimaarbeid', description: 'Norwegian word "klimaarbeid" -> "klimaarbeid"' },
+			{ input: 'KLIMAARBEID', output: 'KLIMAARBEID', description: 'Norwegian word "KLIMAARBEID" -> "KLIMAARBEID"' },
+			{ input: 'klimaavtale', output: 'klimaavtale', description: 'Norwegian word "klimaavtale" -> "klimaavtale"' },
+			{ input: 'KLIMAAVTALE', output: 'KLIMAAVTALE', description: 'Norwegian word "KLIMAAVTALE" -> "KLIMAAVTALE"' },
+			{ input: 'dataanlegg', output: 'dataanlegg', description: 'Norwegian word "dataanlegg" -> "dataanlegg"' },
+			{ input: 'DATAANLEGG', output: 'DATAANLEGG', description: 'Norwegian word "DATAANLEGG" -> "DATAANLEGG"' },
+			{ input: 'aaa', output: 'aa', description: 'Norwegian old aaa -> aa' },
+			{ input: 'aAa', output: 'Aa', description: 'Norwegian old aAa -> Aa' },
+			{ input: 'Aaa', output: 'Aa', description: 'Norwegian old Aaa -> Aa' },
+			{ input: 'AAa', output: 'Aa', description: 'Norwegian old AAa -> Aa' },
+			{ input: 'aaA', output: 'aA', description: 'Norwegian old aaA -> aA' },
+			{ input: 'aAA', output: 'AA', description: 'Norwegian old aAA -> AA' },
+			{ input: 'AaA', output: 'AA', description: 'Norwegian old AaA -> AA' },
+			{ input: 'AAA', output: 'AA', description: 'Norwegian old AAA -> AA' }
+
+		],
+		inputmethod: 'nb-normforms',
+		multiline: true
+	},
+	{
+		description: 'Norwegian Transliteration test for tilde forms',
+		tests: [
+			{ input: '°a', output: 'å', description: 'Norwegian °a -> å' },
+			{ input: '°A', output: 'Å', description: 'Norwegian °A -> Å' },
+			{ input: '~ae', output: 'æ', description: 'Norwegian ~ae -> æ' },
+			{ input: '~AE', output: 'Æ', description: 'Norwegian ~AE -> Æ' },
+			{ input: '~oe', output: 'ø', description: 'Norwegian ~oe -> ø' },
+			{ input: '~OE', output: 'Ø', description: 'Norwegian ~OE -> Ø' },
+			{ input: '~aa', output: 'å', description: 'Norwegian ~aa -> å' },
+			{ input: '~AA', output: 'Å', description: 'Norwegian ~AA -> Å' }
+		],
+		inputmethod: 'nb-tildeforms',
+		multiline: true
+	},
+	{
 		description: 'Amharic Transliteration test',
 		tests: [
 			{ input: 'k', output: 'ክ', description: 'Amharic k -> ክ' },


### PR DESCRIPTION
This version for Bokmål and Nynorsk reuse a common baseform, which provide transliteration of some non-character entities.

This change set depends on #469 and replaces the somewhat messy #461.

