### PR TITLE
Add the Akan keyboard also for Twi

### DIFF
--- a/rules/ak/ak-qx.js
+++ b/rules/ak/ak-qx.js
@@ -3,7 +3,7 @@
 
 	var defs = {
 		id: 'ak-qx',
-		name: 'Akan - QX replacement',
+		name: 'QX replacement',
 		description: 'Akan input method with Q and X replaced by Ɛ and Ɔ',
 		date: '2016-06-23',
 		URL: 'http://www.kasahorow.org/node/260',

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -7,7 +7,7 @@
 			source: 'rules/am/am-transliteration.js'
 		},
 		'ak-qx': {
-			name: 'Akan - QX replacement',
+			name: 'QX replacement',
 			source: 'rules/ak/ak-qx.js'
 		},
 		'ar-kbd': {
@@ -997,6 +997,10 @@
 		tkr: {
 			autonym: 'цӀаӀхна миз',
 			inputmethods: [ 'cyrl-palochka' ]
+		},
+		tw: {
+			autonym: 'Twi',
+			inputmethods: [ 'ak-qx' ]
 		},
 		tzm: {
 			autonym: 'ⵜⴰⵎⴰⵣⵉⵖⵜ',


### PR DESCRIPTION
Akan and Twi languages use the same additional letters
in their writing systems, so they can use the same keyboard layout.

This was requested by Wikipedia user Rberchie, who is a Twi speaker,
at the 2017 Wikimedia conference.

This patch also renames the layout by removing "Akan", because it is
now shared by several languages.