### PR TITLE
Add palochka keyboard layout for Ingush

### DIFF
--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -910,6 +910,10 @@
 			autonym: 'छत्तीसगढ़ी',
 			inputmethods: [ 'hi-transliteration' ]
 		},
+		inh: {
+			autonym: 'гӀалгӀай',
+			inputmethods: [ 'cyrl-palochka' ]
+		},
 		is: {
 			autonym: 'Íslenska',
 			inputmethods: [ 'is-normforms' ]


### PR DESCRIPTION
To be used on https://inh.wikipedia.org/wiki/Керттера_оагӀув

Probably, in the long run, someone should check for other languages with [palochka](https://en.wikipedia.org/wiki/Palochka) used and add them ahead of time.