### PR TITLE
Fix grunt concat for license

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function ( grunt ) {
 				+ '<%= grunt.template.today("yyyymmdd") %>\n'
 				+ '<%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>'
 				+ '* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;'
-				+ ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */\n'
+				+ ' License: <%= pkg.license %> */\n'
 		},
 		concat: {
 			options: {


### PR DESCRIPTION
In package.json `licenses` was converted to simple string `license`. Using that verbatim now.