### PR TITLE
Updates for the Fon language

### DIFF
--- a/rules/fon/fon-tilde.js
+++ b/rules/fon/fon-tilde.js
@@ -6,10 +6,10 @@
 		name: 'fon-tilde',
 		description: 'Fon input keyboard',
 		date: '2018-05-18',
-		URL: 'http://github.com/wikimedia/jquery.ime',
-		author: 'Mahuton POSSOUPE',
+		URL: 'https://github.com/wikimedia/jquery.ime',
+		author: 'Mahuton POSSOUPE, Amir E. Aharoni',
 		license: 'GPLv3',
-		version: '1.0',
+		version: '1.1',
 		patterns: [
 			[ '~D', 'Ɖ' ],
 			[ '~d', 'ɖ' ],
@@ -17,8 +17,11 @@
 			[ '~e', 'ɛ' ],
 			[ '~O', 'Ɔ' ],
 			[ '~o', 'ɔ' ],
-			[ '~/', '\u0341' ], // Combining acute tone mark
-			[ '~\\\\', '\u0340' ] // Combining grave tone mark
+			[ '~\\\\', '\u0300' ], // Combining grave accent
+			[ '~/', '\u0301' ], // Combining acute accent
+			[ '~\\^', '\u0302' ], // Combining circumflex accent
+			[ '~-', '\u0304' ], // Combining macron
+			[ '~v', '\u030C' ] // Combining caron
 		]
 	};
 

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -4134,11 +4134,15 @@ var palochkaVariants = {
 		description: 'Fon tilde test',
 		tests: [
 			{ input: '~D', output: 'Ɖ', description: 'fon ~D -> Ɖ' },
-			{ input: '~d', output:'ɖ' , description: 'fon ~d -> ɖ' },
+			{ input: '~d', output: 'ɖ', description: 'fon ~d -> ɖ' },
 			{ input: '~E', output: 'Ɛ', description: 'fon ~E -> Ɛ' },
-			{ input: '~e', output: 'ɛ', description: 'fon ~e -> ɛ '},
+			{ input: '~e', output: 'ɛ', description: 'fon ~e -> ɛ' },
 			{ input: '~O', output: 'Ɔ', description: 'fon ~O -> Ɔ' },
-			{ input: '~o', output: 'ɔ', description: 'fon ~o -> ɔ' }
+			{ input: '~o~\\', output: 'ɔ̀', description: 'fon ~o~\\ -> ɔ̀' },
+			{ input: '~e~/', output: 'ɛ́', description: 'fon ~e~/ -> ɛ́' },
+			{ input: 'i~v', output: 'ǐ', description: 'fon i~v -> ǐ' },
+			{ input: 'u~-', output: 'ū', description: 'fon u~- -> ū' },
+			{ input: 'o~^', output: 'ô', description: 'fon o~^ -> ô' }
 		],
 		inputmethod: 'fon-tilde'
 	}


### PR DESCRIPTION
* Change the autonym to be the same as in language-data.
* Add caron and macron diacritics.
* Change tone marks characteres to accents.
  They have the same appearance, but are safer to use on older machines.
* Fix whitespace in tests.