### PR TITLE
Update jquery to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^21.0.0",
     "grunt-stylelint": "^0.10.1",
-    "jquery": "3.3.1",
+    "jquery": "^3.4.0",
     "qunitjs": "1.22.0",
     "stylelint": "^9.9.0",
     "stylelint-config-wikimedia": "0.5.0"


### PR DESCRIPTION
Recommended by npm audit and GitHub for security reasons.