### PR TITLE
Clean up the Palochka layout, and add the ~1 rule

### DIFF
--- a/rules/cyrl/cyrl-palochka.js
+++ b/rules/cyrl/cyrl-palochka.js
@@ -6,10 +6,14 @@
  *
  * This layout assumes that the standard Russian keyboard layout is used. All the rules produce the
  * same character palochka, and the characters used are the same that are often used by the speakers
- * of these languages online: 1. Latin small 'l'. 2. Latin capital 'I'. 3. Ukrainian capital 'І'. 4.
- * Alt-1 (the digit one). 5. Alt-д (Cyrillic small 'de', on the same key as Latin 'l'). 6. Alt-ш
- * (Cyrillic small 'sha', on the same key as Latin 'i'). 7. Alt-Ш (Cyrillic capital 'sha', on the
- * same key as Latin 'I').
+ * of these languages online:
+ * 1. Latin small 'l'.
+ * 2. Latin capital 'I'.
+ * 3. Ukrainian capital 'І'.
+ * 4. Alt-1 (the digit one).
+ * 5. Alt-д (Cyrillic small 'de', on the same key as Latin 'l').
+ * 6. Alt-ш (Cyrillic small 'sha', on the same key as Latin 'i').
+ * 7. Alt-Ш (Cyrillic capital 'sha', on the same key as Latin 'I').
  */
 
 ( function ( $ ) {

--- a/rules/cyrl/cyrl-palochka.js
+++ b/rules/cyrl/cyrl-palochka.js
@@ -36,8 +36,12 @@
 		URL: 'http://github.com/wikimedia/jquery.ime',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
-		version: '1.0',
+		version: '1.1',
+		contextLength: 2,
+		maxKeyLength: 3,
 		patterns: [
+			[ '~~' + digitOne, '~~', '~1' ],
+			[ '~' + digitOne, palochka ],
 			[ latinSmallL, palochka ],
 			[ latinCapitalI, palochka ],
 			[ ukrainianCapitalI, palochka ]

--- a/rules/cyrl/cyrl-palochka.js
+++ b/rules/cyrl/cyrl-palochka.js
@@ -14,9 +14,15 @@
 
 ( function ( $ ) {
 	'use strict';
-	// All the characters are very similar in appearance,
-	// so it's better to give them names to avoid confusion.
-	var cyrlPalochka;
+
+	var cyrlPalochka,
+    // All the characters are very similar in appearance,
+    // so it's better to give them names to avoid confusion.
+    latinSmallL = 'l',
+    latinCapitalI = 'I',
+    ukrainianCapitalI = 'І',
+    palochka = 'Ӏ',
+    digitOne = '1';
 
 	cyrlPalochka = {
 		id: 'cyrl-palochka',
@@ -28,14 +34,16 @@
 		license: 'GPLv3',
 		version: '1.0',
 		patterns: [
-			[ 'l', 'Ӏ' ],
-			[ 'I', 'Ӏ' ],
-			[ 'І', 'Ӏ' ] ],
+			[ latinSmallL, palochka ],
+			[ latinCapitalI, palochka ],
+			[ ukrainianCapitalI, palochka ]
+    ],
 		patterns_x: [
-			[ '1', 'Ӏ' ],
-			[ 'д', 'Ӏ' ],
-			[ 'ш', 'Ӏ' ],
-			[ 'Ш', 'Ӏ' ] ]
+			[ digitOne, palochka ],
+			[ 'д', palochka ],
+			[ 'ш', palochka ],
+			[ 'Ш', palochka ]
+    ]
 	};
 
 	$.ime.register( cyrlPalochka );

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -954,19 +954,22 @@ var palochkaVariants = {
 		description: 'Cyrillic with palochka transliteration test',
 		inputmethod: 'cyrl-palochka',
 		tests: [
-			// Sanity test - palochka should produce itself
 			{ input: palochkaVariants.palochka, output: palochkaVariants.palochka, description: 'Palochka itself is unchanged' },
 
 			{ input: 'L', output: 'L', description: 'Latin capital L is unchanged' },
 			{ input: palochkaVariants.latinSmallL, output: palochkaVariants.palochka, description: 'Latin small l becomes palochka' },
 
 			{ input: palochkaVariants.latinCapitalI, output: palochkaVariants.palochka, description: 'Latin capital I becomes palochka' },
-			{ input: 'i', output: 'i', description: 'Latin small i becomes palochka' },
+			{ input: 'i', output: 'i', description: 'Latin small i is unchanged' },
 
 			{ input: palochkaVariants.ukrainianCapitalI, output: palochkaVariants.palochka, description: 'Ukrainian capital І becomes palochka' },
 
 			{ input: palochkaVariants.digitOne, output: palochkaVariants.digitOne, description: 'Digit one (1) is unchanged' },
 			{ input: [ [ palochkaVariants.digitOne, true ] ], output: palochkaVariants.palochka, description: 'Extended digit one (1) becomes palochka' },
+
+			{ input: 'Мях~1ячкъала', output: 'МяхӀячкъала', description: 'Tilde 1 produces palochka' },
+			{ input: '~~100', output: '~100', description: 'Two tildes and 1 produce ~1 and not palochka' },
+			{ input: '~~~~', output: '~~~~', description: 'Four tildes are unchanged' },
 
 			{ input: 'д', output: 'д', description: 'Cyrillic small д is is unchanged' },
 			{ input: [ [ 'д', true ] ], output: palochkaVariants.palochka, description: 'Extended Cyrillic д becomes palochka' },


### PR DESCRIPTION
1. Make the code more readable by using variables instead of explicit characters, which look very similar to each other.
2. Add whitespace to the big comment at the top of the rules file.
3. Add the ~1 rule, to make the character more accessible, and also the ~~1 to make typing an explicit digit one possible.
4. Bump the version number to 1.1.