### PR TITLE
Remove the one-var definition from .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
 		"camelcase": "off",
 		"comma-spacing": "off",
 		"indent": "off",
-		"max-len": "off",
-		"one-var": [ "error", { "var": "always" } ]
+		"max-len": "off"
 	}
 }


### PR DESCRIPTION
According to https://eslint.org/docs/rules/one-var, this
is the default behavior, so there's no need to configure it
explicitly.