### PR TITLE
Add Mon Simplified Anonta keyboard

### DIFF
--- a/rules/mnw/mnw-simplified-anonta.js
+++ b/rules/mnw/mnw-simplified-anonta.js
@@ -1,0 +1,105 @@
+( function ( $ ) {
+	'use strict';
+
+	var mnwAnonta = {
+		id: 'mnw-simplified-anonta',
+		name: 'Mon Simplified Anonta',
+		description: 'Mon Simplified Anonta keyboard layout',
+		date: '2021-11-08',
+		URL: 'https://help.keyman.com/keyboard/mon_anonta/1.0.1/mon_anonta',
+		author: 'Amir E. Aharoni, based on Keyman',
+		license: 'GPLv3',
+		version: '1.0',
+		patterns: [
+			[ '`', 'ၝ' ],
+			[ '~', 'ဎ' ],
+			[ '1', '၁' ],
+			[ '!', 'ဍ' ],
+			[ '2', '၂' ],
+			[ '@', 'ဏ္ဍ' ],
+			[ '3', '၃' ],
+			[ '#', 'ဋ' ],
+			[ '4', '၄' ],
+			[ '\\$', '\u102D\u1032' ], // SIGN I and SIGN AI
+			[ '5', '၅' ],
+			[ '6', '၆' ],
+			[ '\\^', '\u1035' ], // SIGN E ABOVE
+			[ '7', '၇' ],
+			[ '&', 'ရ' ],
+			[ '8', '၈' ],
+			[ '\\*', 'ဂ' ],
+			[ '9', '၉' ],
+			[ '0', '၀' ],
+			[ '_', '×' ],
+
+			[ 'q', 'ဆ' ],
+			[ 'Q', 'ၛ' ],
+			[ 'w', 'တ' ],
+			[ 'W', 'ဝ' ],
+			[ 'e', 'န' ],
+			[ 'E', 'ဣ' ],
+			[ 'r', 'မ' ],
+			[ 'R', '\u105F' ], // MON MON MEDIAL MA
+			[ 't', 'အ' ],
+			[ 'T', '\u1033' ], // MON II
+			[ 'y', 'ပ' ],
+			[ 'Y', '\u1060' ], // MON MEDIAL LA
+			[ 'u', 'က' ],
+			[ 'U', 'ဥ' ],
+			[ 'i', 'ၚ' ],
+			[ 'I', '၎' ],
+			[ 'o', 'သ' ],
+			[ 'O', 'ဿ' ],
+			[ 'p', 'စ' ],
+			[ 'P', 'ဏ' ],
+			[ '\\[', 'ဟ' ],
+			[ '\\{', 'ဨ' ],
+			[ '\\]', 'ဩ' ],
+			[ '\\}', 'အဴ' ], // A and SIGN MON O
+			[ '\\\\', 'ၑ' ],
+			[ '\\|', 'ဋ္ဌ' ], // TTA and VIRAMA and TTHA
+
+			[ 'a', '\u1031' ], // SIGN E
+			[ 'A', 'ဗ' ],
+			[ 's', '\u103B' ], // SIGN MEDIAL YA
+			[ 'S', '\u103E' ], // SIGN MEDIAL HA
+			[ 'd', '\u102D' ], // SIGN I
+			[ 'D', '\u102E' ], // SIGN II
+			[ 'f', '\u103A' ], // ASAT
+			[ 'F', '\u1039' ], // VIRAMA
+			[ 'g', '\u102B' ], // TALL AA
+			[ 'G', '\u103D' ], // MEDIAL WA
+			[ 'h', '\u1034' ], // SIGN MON O
+			[ 'H', '\u1036' ], // ANUSVARA
+			[ 'j', '\u103C' ], // SIGN MEDIAL RA
+			[ 'J', '\u1032' ], // SIGN AI
+			[ 'k', '\u102F' ], // SIGN U
+			[ 'K', 'ဒ' ],
+			[ 'l', '\u1030' ], // SIGN UU
+			[ 'L', 'ဓ' ],
+			[ ';', '\u1038' ], // VISARGA
+
+			[ 'z', 'ဖ' ],
+			[ 'Z', 'ဇ' ],
+			[ 'x', 'ထ' ],
+			[ 'X', 'ဌ' ],
+			[ 'c', 'ခ' ],
+			[ 'C', 'ဃ' ],
+			[ 'v', 'လ' ],
+			[ 'V', 'ဠ' ],
+			[ 'b', 'ဘ' ],
+			[ 'B', 'ၐ' ],
+			[ 'n', 'ည' ],
+			[ 'N', 'ဉ' ],
+			[ 'm', '\u102C' ], // SIGN AA
+			[ 'M', '÷' ],
+			[ ',', 'ယ' ],
+			[ '\\<', '\u105E' ], // MON MEDIAL NA
+			[ '\\.', 'ၜ' ],
+			[ '/', '။' ],
+			[ '\\?', '၊' ]
+		],
+	};
+
+	$.ime.register( mnwAnonta );
+}( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -538,6 +538,10 @@
 			name: 'ইনস্ক্ৰিপ্ট ২',
 			source: 'rules/mni/mni-inscript2.js'
 		},
+		'mnw-simplified-anonta': {
+			name: 'Mon Simplified Anonta',
+			source: 'rules/mnw/mnw-simplified-anonta.js'
+		},
 		'mr-inscript': {
 			name: 'मराठी लिपी',
 			source: 'rules/mr/mr-inscript.js'
@@ -1233,6 +1237,10 @@
 		mni: {
 			autonym: 'Manipuri',
 			inputmethods: [ 'mni-inscript2' ]
+		},
+		mnw: {
+			autonym: 'ဘာသာ မန်',
+			inputmethods: [ 'mnw-simplified-anonta' ]
 		},
 		mr: {
 			autonym: 'मराठी',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -4040,6 +4040,38 @@ var palochkaVariants = {
 		]
 	},
 	{
+		description: 'Mon Simplified Anonta test',
+		inputmethod: 'mnw-simplified-anonta',
+		tests: [
+			{ input: '`1234567890', output: 'ၝ၁၂၃၄၅၆၇၈၉၀', description: 'Mon Simplified Anonta - `1234567890' },
+			{ input: '~!@#', output: 'ဎဍဏ္ဍဋ', description: 'Mon Simplified Anonta - ~!@#' },
+			{ input: 'r$', output: 'မိဲ', description: 'Mon Simplified Anonta - r$' },
+			{ input: 'y^', output: 'ပဵ', description: 'Mon Simplified Anonta - y^' },
+			{ input: '&*_', output: 'ရဂ×', description: 'Mon Simplified Anonta - &*_' },
+			{ input: 'qwertyuiop[]\\', output: 'ဆတနမအပကၚသစဟဩၑ', description: 'Mon Simplified Anonta - qwertyuiop[]\\' },
+			{ input: 'za', output: 'ဖေ', description: 'Mon Simplified Anonta - za' },
+			{ input: 'xs', output: 'ထျ', description: 'Mon Simplified Anonta - xs' },
+			{ input: 'cd', output: 'ခိ', description: 'Mon Simplified Anonta - cd' },
+			{ input: 'vf', output: 'လ်', description: 'Mon Simplified Anonta - vf' },
+			{ input: 'bg', output: 'ဘါ', description: 'Mon Simplified Anonta - bg' },
+			{ input: 'nh', output: 'ညဴ', description: 'Mon Simplified Anonta - nh' },
+			{ input: ',m', output: 'ယာ', description: 'Mon Simplified Anonta - ,m' },
+			{ input: '.j/', output: 'ၜြ။', description: 'Mon Simplified Anonta - .j/' },
+			{ input: 'zkxl;', output: 'ဖုထူး', description: 'Mon Simplified Anonta - zkxl;' },
+			{ input: 'QRWT', output: 'ၛၟဝဳ', description: 'Mon Simplified Anonta - QRWT' },
+			{ input: 'E', output: 'ဣ', description: 'Mon Simplified Anonta - E' },
+			{ input: 'UIOP{}|', output: 'ဥ၎ဿဏဨအဴဋ္ဌ', description: 'Mon Simplified Anonta - UIOP{}|' },
+			{ input: 'AY', output: 'ဗၠ', description: 'Mon Simplified Anonta - AY' },
+			{ input: 'ZS', output: 'ဇှ', description: 'Mon Simplified Anonta - ZS' },
+			{ input: 'XD', output: 'ဌီ', description: 'Mon Simplified Anonta - XD' },
+			{ input: 'CF', output: 'ဃ္', description: 'Mon Simplified Anonta - CF' },
+			{ input: 'BG', output: 'ၐွ', description: 'Mon Simplified Anonta - BG' },
+			{ input: 'VH', output: 'ဠံ', description: 'Mon Simplified Anonta - VH' },
+			{ input: 'NJ', output: 'ဉဲ', description: 'Mon Simplified Anonta - NJ' },
+			{ input: 'K<ML?', output: 'ဒၞ÷ဓ၊', description: 'Mon Simplified Anonta - K<ML?' }
+		]
+	},
+	{
 		description: 'Marathi InScript 2 test',
 		inputmethod: 'mr-inscript2',
 		tests: [


### PR DESCRIPTION
Requested in translatewiki:
https://translatewiki.net/wiki/Thread:Support/Want_to_ask_two_quick_questions

It's based on the Mon Anonta layout distributed
by Keyman:
https://help.keyman.com/keyboard/mon_anonta/1.0.1/mon_anonta.php

The main change is that the use of VOWEL SIGN E on the 'a'
key is simplified, so it's typed after the vowel and not before it.
Getting it to be typed before the letter is a bit too complicated
for jquery.ime.