### PR TITLE
Add Burkina Faso tilde keyboard

### DIFF
--- a/rules/mul-bf/mul-bf.js
+++ b/rules/mul-bf/mul-bf.js
@@ -1,0 +1,48 @@
+( function ( $ ) {
+	'use strict';
+
+	var mulBf = {
+		id: 'mul-bf',
+		name: 'mul-bf',
+		description: 'Burkina Faso tilde keyboard',
+		date: '2022-02-14',
+		URL: 'https://github.com/wikimedia/jquery.ime',
+		author: 'Amir E. Aharoni',
+		license: 'GPLv3',
+		version: '1.0',
+		maxKeyLength: 2,
+		patterns: [
+			[ '~B', 'Ɓ' ],
+			[ '~b', 'ɓ' ],
+			[ '~C', 'Ç' ],
+			[ '~c', 'ç' ],
+			[ '~D', 'Ɗ' ],
+			[ '~d', 'ɗ' ],
+			[ '~A', 'Ǝ' ],
+			[ '~a', 'ǝ' ],
+			[ '~E', 'Ɛ' ],
+			[ '~e', 'ɛ' ],
+			[ '~I', 'Ɩ' ],
+			[ '~i', 'ɩ' ],
+			[ '~N', 'Ŋ' ],
+			[ '~n', 'ŋ' ],
+			[ '~O', 'Ɔ' ],
+			[ '~o', 'ɔ' ],
+			[ '~U', 'Ʋ' ],
+			[ '~u', 'ʋ' ],
+			[ '~W', 'Ⱳ' ],
+			[ '~w', 'ⱳ' ],
+			[ '~Y', 'Ƴ' ],
+			[ '~y', 'ƴ' ],
+			[ '~\\\\', '\u0300' ], // Combining grave accent
+			[ '~/', '\u0301' ], // Combining acute accent
+			[ '~\\^', '\u0302' ], // Combining circumflex accent
+			[ '~\\{', '\u0303' ], // Combining tilde
+			[ '~-', '\u0304' ], // Combining macron
+			[ '~:', '\u0308' ], // Combining diaeresis
+			[ '~v', '\u030C' ] // Combining caron
+		]
+	};
+
+	$.ime.register( mulBf );
+}( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -562,6 +562,10 @@
 			name: 'अक्षरांतरण',
 			source: 'rules/mr/mr-transliteration.js'
 		},
+		'mul-bf': {
+			name: 'Burkina Faso tilde keyboard',
+			source: 'rules/mul-bf/mul-bf.js'
+		},
 		'mul-cm': {
 			name: 'General Alphabet of Cameroon Languages tilde keyboard',
 			source: 'rules/mul-cm/mul-cm.js'
@@ -1257,6 +1261,10 @@
 		mnw: {
 			autonym: 'ဘာသာ မန်',
 			inputmethods: [ 'mnw-simplified-anonta' ]
+		},
+		mos: {
+			autonym: 'moore',
+			inputmethods: [ 'mul-bf' ]
 		},
 		mr: {
 			autonym: 'मराठी',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -4234,6 +4234,36 @@ var palochkaVariants = {
 		]
 	},
 	{
+		description: 'Burkina Faso tilde keyboard test',
+		inputmethod: 'mul-bf',
+		tests: [
+			{ input: '~B', output: 'Ɓ', description: 'Burkina Faso tilde keyboard - Ɓ' },
+			{ input: '~b', output: 'ɓ', description: 'Burkina Faso tilde keyboard - ɓ' },
+			{ input: '~C', output: 'Ç', description: 'Burkina Faso tilde keyboard - Ç' },
+			{ input: '~c', output: 'ç', description: 'Burkina Faso tilde keyboard - ç' },
+			{ input: '~D', output: 'Ɗ', description: 'Burkina Faso tilde keyboard - Ɗ' },
+			{ input: '~d', output: 'ɗ', description: 'Burkina Faso tilde keyboard - ɗ' },
+			{ input: '~A', output: 'Ǝ', description: 'Burkina Faso tilde keyboard - Ǝ' },
+			{ input: '~a', output: 'ǝ', description: 'Burkina Faso tilde keyboard - ǝ' },
+			{ input: '~E', output: 'Ɛ', description: 'Burkina Faso tilde keyboard - Ɛ' },
+			{ input: '~e', output: 'ɛ', description: 'Burkina Faso tilde keyboard - ɛ' },
+			{ input: '~I', output: 'Ɩ', description: 'Burkina Faso tilde keyboard - Ɩ' },
+			{ input: '~i', output: 'ɩ', description: 'Burkina Faso tilde keyboard - ɩ' },
+			{ input: '~N', output: 'Ŋ', description: 'Burkina Faso tilde keyboard - Ŋ' },
+			{ input: '~n', output: 'ŋ', description: 'Burkina Faso tilde keyboard - ŋ' },
+			{ input: '~O', output: 'Ɔ', description: 'Burkina Faso tilde keyboard - Ɔ' },
+			{ input: '~o', output: 'ɔ', description: 'Burkina Faso tilde keyboard - ɔ' },
+			{ input: 'u~:', output: 'ü', description: 'Burkina Faso tilde keyboard - ü' },
+			{ input: '~U', output: 'Ʋ', description: 'Burkina Faso tilde keyboard - Ʋ' },
+			{ input: '~u', output: 'ʋ', description: 'Burkina Faso tilde keyboard - ʋ' },
+			{ input: '~W', output: 'Ⱳ', description: 'Burkina Faso tilde keyboard - Ⱳ' },
+			{ input: '~w', output: 'ⱳ', description: 'Burkina Faso tilde keyboard - ⱳ' },
+			{ input: '~Y', output: 'Ƴ', description: 'Burkina Faso tilde keyboard - Ƴ' },
+			{ input: '~y', output: 'ƴ', description: 'Burkina Faso tilde keyboard - ƴ' },
+			{ input: 'a~{', output: 'ã', description: 'Burkina Faso tilde keyboard - ã' }
+		]
+	},
+	{
 		description: 'General Alphabet of Cameroon Languages tilde keyboard test',
 		inputmethod: 'mul-cm',
 		tests: [


### PR DESCRIPTION
For the Moore language, which was recently added
to translatewiki.