### PR TITLE
Add Fante language with Akan keyboards

### DIFF
--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -1058,6 +1058,10 @@
 			autonym: 'فارسی',
 			inputmethods: [ 'fa-kbd' ]
 		},
+		fat: {
+			autonym: 'mfantse',
+			inputmethods: [ 'ak-qx', 'ak-tilde' ]
+		},
 		ff: {
 			autonym: 'Fulfulde',
 			inputmethods: [ 'ff-alt', 'ff-tilde' ]


### PR DESCRIPTION
Akan, Twi and Fante are one group and have
the same alphabet.