### PR TITLE
Fix height of selected keyboard text

### DIFF
--- a/css/jquery.ime.css
+++ b/css/jquery.ime.css
@@ -8,7 +8,7 @@
 	background-image: linear-gradient( transparent, transparent ), url( ../images/ime-active.svg );
 	background-color: rgba( 255, 255, 255, 0.75 );
 	background-position: left 3px center;
-	height: 15px;
+	min-height: 15px;
 	font-size: small;
 	padding: 2px 2px 1px 20px;
 	box-shadow: 0 1px 3px 0 #777;


### PR DESCRIPTION
When users have zoomed text (for accessibility for instance),
after selecting a keyboard, the text might overflow the imeselector,
because it had a restricted height of 15px. Set it as min-height
instead.

Bug: T309918