### PR TITLE
Gurmukhi transliteration: addressed overapplication of virama, normalized nukta characters

### DIFF
--- a/rules/pa/pa-transliteration.js
+++ b/rules/pa/pa-transliteration.js
@@ -5,11 +5,11 @@
 		id: 'pa-transliteration',
 		name: 'Punjabi Transliteration',
 		description: 'Punjabi transliteration',
-		date: '2012-10-16',
+		date: '2022-08-28',
 		URL: 'http://github.com/wikimedia/jquery.ime',
-		author: 'Amir E. Aharoni, inputs from Saurabh Choudhary and Surinder Wadhawan',
+		author: 'Amir E. Aharoni, inputs from Saurabh Choudhary, Surinder Wadhawan, bgo_eiu',
 		license: 'GPLv3',
-		version: '1.0',
+		version: '2.0',
 		contextLength: 2,
 		maxKeyLength: 4,
 		/* Semi-automatically created from the Hindi transliteration mapping using
@@ -17,23 +17,23 @@
 		 * s{(?<deva_letter>[ऀ-ॿ])}{chr(ord($+{deva_letter}) + 0x100)}xmsge;
 		 */
 		patterns: [
-			[ 'ਕ੍h', 'c', 'ਚ੍' ],
+			[ 'ਕh', 'c', 'ਚ' ],
 			[ '\\\\([A-Za-z\\>_~\\.0-9])', '\\\\', '$1' ],
 
 			// ਕ-ਹ is the main range of Indic letters.
-			// ੜ is an additional unique Gurmukhi letter.
-			[ '([ਕ-ਹੜ]਼?)੍a', '$1' ], // Short [a] after a consonant with virama removes the virama
-			[ '([ਕ-ਹੜ]਼?)੍A', '$1ਾ' ], // Long [a] after a consonant with virama removes the virama and adds long [a]
-			[ '([ਕ-ਹੜ]਼?)a', '$1ਾ' ], // 'aa' gives long [a] - short [a] after a consonant without virama adds long [a]
-			[ '([ਕ-ਹੜ]਼?)੍i', '$1ਿ' ],
-			[ '([ਕ-ਹੜ]਼?)(ਿi|੍I|ੇe)', '$1ੀ' ], // 'ii', 'I' and 'ee' give long [i].
-			[ '([ਕ-ਹੜ]਼?)੍u', '$1ੁ' ],
-			[ '([ਕ-ਹੜ]਼?)(ੁu|੍U|ੋo)', '$1ੂ' ], // 'uu', 'U' and 'oo' give long [u].
-			[ '([ਕ-ਹੜ]਼?)੍e', '$1ੇ' ],
-			[ '([ਕ-ਹੜ]਼?)(i|੍E)', '$1ੈ' ], // 'i' after a consonant without virama or 'E' after a consonant with Virama gives "ai"
-			[ '([ਕ-ਹੜ]਼?)੍[oO]', '$1ੋ' ],
-			[ '([ਕ-ਹੜ]਼?)u', '$1ੌ' ], // 'u' after a consonant without virama gives "au"
-			[ '([ਕ-ਹੜ])੍\\`', '$1਼੍' ], // '`' (backtick) after a consonant with virama adds a nukta before the virama
+			// ਖ਼, ਗ਼, ਜ਼, ੜ, ਫ਼ is are additional Gurmukhi letters.
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)', '$1' ],
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)a', '$1ਾ' ], // 'a' after a consonant adds long [a]
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)i', '$1ਿ' ],
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)(ਿi|I|ੇe)', '$1ੀ' ], // 'ii', 'I' and 'ee' give long [i].
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)u', '$1ੁ' ],
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)(ੁu|U|ੋo)', '$1ੂ' ], // 'uu', 'U' and 'oo' give long [u].
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)e', '$1ੇ' ],
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)E', '$1ੈ' ], // 'E' after a consonant gives "ai"
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)o', '$1ੋ' ],
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼]਼?)O', '$1ੌ' ], // 'u' after a consonant gives "au"
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼])~', '$1ੑ' ], // '~' after a consonant adds virama
+			[ '([ਕ-ਹਖ਼ਗ਼ਜ਼ੜਫ਼])੍\\`', '$1਼੍' ], // '`' (backtick) after a consonant with virama adds a nukta before the virama
 
 			[ 'ਅa', 'ਆ' ], // aa
 			[ '(ਓo|ਉu)', 'ਊ' ], // oo, uu
@@ -43,61 +43,68 @@
 			[ '(ਏe|ਇi)', 'ਈ' ], // ee, ii
 			[ 'ਅu', 'ਔ' ], // au
 			[ 'ਂ[Mm^]', 'ਁ' ], // bindi + 'm', 'M', or '^' -> Adak bindi
-			[ 'ਣ੍N', 'ੰ' ], // Tippi - nasalization
+			[ 'ਣN', 'ੰ' ], // Tippi - nasalization
 
-			[ 'ਕ੍h', 'ਖ੍' ], // kh
-			[ 'ਗ੍h', 'ਘ੍' ], // gh
-			[ 'ਨ੍g', 'ਙ੍' ], // ng
-			[ 'ਚ੍h', 'ਛ੍' ], // ch
-			[ 'ਜ੍h', 'ਝ੍' ], // jh
-			[ 'ਨ੍j', 'ਞ੍' ], // nj
-			[ 'ਟ੍h', 'ਠ੍' ], // Th
-			[ 'ਡ੍h', 'ਢ੍' ], // Dh
-			[ 'ਤ੍h', 'ਥ੍' ], // th
-			[ 'ਦ੍h', 'ਧ੍' ], // dh
-			[ 'ਪ੍h', 'ਫ੍' ], // ph
-			[ 'ਬ੍h', 'ਭ੍' ], // bh
+			[ 'ਕh', 'ਖ' ], // kh
+			[ 'ਗh', 'ਘ' ], // gh
+			[ 'ਨg', 'ਙ' ], // ng
+			[ 'ਚh', 'ਛ' ], // ch
+			[ 'ਜh', 'ਝ' ], // jh
+			[ 'ਨj', 'ਞ' ], // nj
+			[ 'ਟh', 'ਠ' ], // Th
+			[ 'ਡh', 'ਢ' ], // Dh
+			[ 'ਤh', 'ਥ' ], // th
+			[ 'ਦh', 'ਧ' ], // dh
+			[ 'ਪh', 'ਫ' ], // ph
+			[ 'ਬh', 'ਭ' ], // bh
 
-			[ 'ਸ੍h', 'ਸ਼੍' ], // sh
-			[ 'ਕ਼੍h', 'ਖ਼੍' ], // k + nukta + h
+			[ 'ਸh', 'ਸ਼' ], // sh
+			[ 'ਕ਼h', 'ਖ਼' ], // k + nukta + h
 
 			[ 'a', 'ਅ' ],
-			[ 'b', 'ਬ੍' ],
-			[ 'c', 'ਚ੍' ],
-			[ 'd', 'ਦ੍' ],
+			[ 'b', 'ਬ' ],
+			[ 'c', 'ਚ' ],
+			[ 'd', 'ਦ' ],
 			[ 'e', 'ਏ' ],
-			[ 'f', 'ਫ੍' ],
-			[ 'F', 'ਫ਼੍' ], // With nukta
-			[ 'g', 'ਗ੍' ],
-			[ 'h', 'ਹ੍' ],
+			[ 'f', 'ਫ' ],
+			[ 'F', 'ਫ਼' ],
+			[ 'g', 'ਗ' ],
+			[ 'h', 'ਹ' ],
 			[ 'i', 'ਇ' ],
-			[ 'j', 'ਜ੍' ],
-			[ 'k', 'ਕ੍' ],
-			[ 'l', 'ਲ੍' ],
-			[ 'm', 'ਮ੍' ],
-			[ 'n', 'ਨ੍' ],
+			[ 'j', 'ਜ' ],
+			[ 'k', 'ਕ' ],
+			[ 'l', 'ਲ' ],
+			[ 'm', 'ਮ' ],
+			[ 'n', 'ਨ' ],
 			[ 'o', 'ਓ' ],
-			[ 'p', 'ਪ੍' ],
-			[ 'q', 'ੑ' ], // Udaat
-			[ 'r', 'ਰ੍' ],
-			[ 's', 'ਸ੍' ],
-			[ 't', 'ਤ੍' ],
+			[ 'p', 'ਪ' ],
+			[ 'q', 'ਕ਼' ],
+			[ 'r', 'ਰ' ],
+			[ 's', 'ਸ' ],
+			[ 't', 'ਤ' ],
 			[ 'u', 'ਉ' ],
 			[ '(v|w)', 'ਵ੍' ],
 			[ 'y', 'ਯ੍' ],
 			[ 'z', 'ੱ' ], // Addak - gemination
 			[ 'A', 'ਆ' ],
-			[ 'D', 'ਡ੍' ],
+			[ 'D', 'ਡ' ],
+			[ 'F', 'ਫ਼' ],
+			[ 'G', 'ਗ਼' ],
 			[ 'H', 'ਃ' ], // Visarga
 			[ 'I', 'ਈ' ],
+			[ 'J', 'ਜ਼' ],
+			[ 'K', 'ਖ਼' ],
+			[ 'L', 'ਲ਼'],
 			[ 'M', 'ਂ' ], // Bindi
-			[ 'N', 'ਣ੍' ],
-			[ 'R', 'ੜ੍' ], // Rra
-			[ 'S', 'ਸ਼੍' ],
-			[ 'T', 'ਟ੍' ],
+			[ 'N', 'ਣ' ],
+			[ 'Q', 'ੑ'], // Udaat
+			[ 'R', 'ੜ' ], // Rra
+			[ 'S', 'ਸ਼' ],
+			[ 'T', 'ਟ' ],
 			[ 'U', 'ਊ' ],
 			[ 'X', 'ੴ' ], // Ek onkar
 			[ 'Y', 'ੵ' ], // Yakash
+			[ 'Z', '.' ],
 			[ '0', '੦' ],
 			[ '1', '੧' ],
 			[ '2', '੨' ],
@@ -112,7 +119,8 @@
 			[ '\\`', '਼' ], // Nukta
 
 			[ '।\\.', '॥' ], // Double danda, must be before single danda
-			[ '\\.', '।' ] ] // Danda
+			[ '\\.', '।' ] // Danda
+		]
 	};
 
 	$.ime.register( paTransliteration );


### PR DESCRIPTION
Addresses https://phabricator.wikimedia.org/T91159

1. Halant/virama no longer applies by default. A tilde ~ may simply be typed instead. The reasons to use conjunct characters in Gurmukhi are too rare to justify placing this everywhere by default.
2. While it is true that there are only three common conjuncts as pointed out in the issue, the tilde would allow input of the 3 common ones and the uncommon ones alike.
3. Numerals left alone per request from other users.
4. Full stop may be added now with 'Z'; this is what Hindi transliteration input already does

Additional: normalized the nukta characters by using the standalone unicode characters for them wherever possible rather than combining characters. Made 'q' kaka pair bindi because even though this is not that common, it is still more common than udaat, which I have changed to 'Q'. Added ways to type all the common nukta/bindi combinations.