### PR TITLE
Emit event when text has changed

### DIFF
--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -556,9 +556,8 @@
 			element.value.substring( element.selectionEnd, element.value.length );
 
 		// Emit an event so that input fields that rely on events
-		// work properly.
+		// work properly
 		element.dispatchEvent( new Event( 'input' ) );
-
 
 		// restore scroll
 		element.scrollTop = scrollTop;

--- a/src/jquery.ime.js
+++ b/src/jquery.ime.js
@@ -555,6 +555,11 @@
 			newText +
 			element.value.substring( element.selectionEnd, element.value.length );
 
+		// Emit an event so that input fields that rely on events
+		// work properly.
+		element.dispatchEvent( new Event( 'input' ) );
+
+
 		// restore scroll
 		element.scrollTop = scrollTop;
 		// set selection


### PR DESCRIPTION
Submitting on behalf of @nikkiwd.

Emit an event when the text changes, so that input fields that rely on such events (such as Wikidata input fields or the new search box) will work properly when using an IME.

This fixes [T200329](https://phabricator.wikimedia.org/T200329).