### PR TITLE
Toba-transliteration version 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 node_modules/
 dist/
 .eslintcache
+rules/jv/jv-transliteration - Copy.js

--- a/rules/bbc/bbc-transliteration.js
+++ b/rules/bbc/bbc-transliteration.js
@@ -7,8 +7,8 @@
 		description: 'QWERTY-based Batak Toba transliteration',
 		date: '2014-04-20',
 		URL: 'http://evertype.com/fonts/batak/',
-		author: 'design by Michael Everson, implementation by Amir E. Aharoni',
-		version: '1.0',
+		author: 'design by Michael Everson, implementation by Amir E. Aharoni and Benny Lin',
+		version: '1.1',
 		patterns: [
 			[ 'q', 'ᯥ' ],
 			[ 'w', 'ᯋ' ],
@@ -52,36 +52,27 @@
 
 			[ 'A', 'ᯁ' ],
 			[ 'S', 'ᯙ' ],
-
+			[ 'D', 'ᯩ' ],
 			[ 'F', '᯳' ],
 			[ 'G', 'ᯏ' ],
 			[ 'H', 'ᯃ' ],
 			[ 'J', 'ᯄ' ],
-
+			[ 'K', 'ᯱ' ],
 			[ 'L', 'ᯟ' ],
 
 			[ 'Z', 'ᯚ' ],
-
+			[ 'X', 'ᯰ' ],
+			[ 'C', 'ᯠ' ],
+			[ 'V', '᯦' ],
 			[ 'B', 'ᯆ' ],
 			[ 'N', 'ᯊ' ],
 			[ 'M', 'ᯕ' ],
-
-			[ '`', 'ᯠ' ],
-			[ '=', 'ᯱ' ],
-			[ '\\+', '᯦' ],
-			[ '-', '' ],
-			[ '_', 'ᯩ' ],
-
-			[ 'B', 'ᯆ' ]
 		],
 		patterns_x: [
 			[ '4', '᯼' ],
 			[ '5', '᯽' ],
 			[ '6', '᯾' ],
-			[ '7', '᯿' ],
-
-			[ 'w', 'ᯍ' ],
-			[ '`', '`' ]
+			[ '7', '᯿' ]
 		]
 	};
 

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -330,36 +330,26 @@ var palochkaVariants = {
 
 			{ input: 'A', output: 'ᯁ', description: 'Toba Transliteration - A - simalungun a' },
 			{ input: 'S', output: 'ᯙ', description: 'Toba Transliteration - S - simalungun sa' },
-
+			{ input: 'D', output: 'ᯩ', description: 'Toba Transliteration - D - talinga' },
 			{ input: 'F', output: '᯳', description: 'Toba Transliteration - F - virama' },
 			{ input: 'G', output: 'ᯏ', description: 'Toba Transliteration - G - simalungun ga' },
 			{ input: 'H', output: 'ᯃ', description: 'Toba Transliteration - H - simalungun ha' },
 			{ input: 'J', output: 'ᯄ', description: 'Toba Transliteration - J - mandailing ha' },
-
+			{ input: 'K', output: 'ᯱ', description: 'Toba Transliteration - K - hajoringan -h' },
 			{ input: 'L', output: 'ᯟ', description: 'Toba Transliteration - L - simalungun la' },
 
 			{ input: 'Z', output: 'ᯚ', description: 'Toba Transliteration - Z - mandailing sa' },
-
+			{ input: 'X', output: 'ᯰ', description: 'Toba Transliteration - X - amisara -ng' },
+			{ input: 'C', output: 'ᯠ', description: 'Toba Transliteration - C - nya / karo ca' },
+			{ input: 'V', output: '᯦', description: 'Toba Transliteration - V - tompi' },
 			{ input: 'B', output: 'ᯆ', description: 'Toba Transliteration - B - karo ba' },
 			{ input: 'N', output: 'ᯊ', description: 'Toba Transliteration - N - mandailing na' },
 			{ input: 'M', output: 'ᯕ', description: 'Toba Transliteration - M - simalungun ma' },
 
-			{ input: '`', output: 'ᯠ', description: 'Toba Transliteration - ` - nya' },
-			{ input: '=', output: 'ᯱ', description: 'Toba Transliteration - = - consonant sign h' },
-			{ input: '+', output: '᯦', description: 'Toba Transliteration - + - tompi' },
-			{ input: '-', output: '', description: 'Toba Transliteration - ng - amisara' },
-			{ input: '_', output: 'ᯩ', description: 'Toba Transliteration - _ - talinga' },
-			{ input: '', output: '', description: 'Toba Transliteration - ' },
-
-			{ input: 'B', output: 'ᯆ', description: 'Toba Transliteration - B - karo ba' },
-
 			{ input: [ [ '4', true ] ], output: '᯼', description: 'Toba Transliteration - alt-4 - bindu na metek' },
 			{ input: [ [ '5', true ] ], output: '᯽', description: 'Toba Transliteration - alt-5 - bindu pinarboras' },
 			{ input: [ [ '6', true ] ], output: '᯾', description: 'Toba Transliteration - alt-6 - bindu judul' },
-			{ input: [ [ '7', true ] ], output: '᯿', description: 'Toba Transliteration - alt-7 - bindu pangolat' },
-
-			{ input: [ [ 'w', true ] ], output: 'ᯍ', description: 'Toba Transliteration - alt-w' },
-			{ input: [ [ '`', true ] ], output: '`', description: 'Toba Transliteration - alt-`' }
+			{ input: [ [ '7', true ] ], output: '᯿', description: 'Toba Transliteration - alt-7 - bindu pangolat' }
 		]
 	},
 	{


### PR DESCRIPTION
Fixing "amisara" that was not included in version 1.0. Repositioning some letters, see https://www.mediawiki.org/w/index.php?title=Help:Extension:UniversalLanguageSelector/Input_methods/batak-qwerty&oldid=6021186 blue lettered ones, abolish special letters ` = + - _ Alt+w, Alt+`

Thank you for Surung Simanullang, Batak Toba Wikipedia contributor in Incubator, for reporting this via https://www.mediawiki.org/wiki/Help_talk:Extension:UniversalLanguageSelector/Input_methods/batak-qwerty and Telegram discussion