### PR TITLE
Drop support for Node 12 in GitHub actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
We want to upgrade qunit. The new version doesn't work with Node 12, and it's already declared end of life.