### PR TITLE
Add typographic apostrophe to Chinook Jargon keyboard

### DIFF
--- a/rules/chn/chn-tilde.js
+++ b/rules/chn/chn-tilde.js
@@ -9,7 +9,7 @@
 		URL: 'https://github.com/wikimedia/jquery.ime',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
-		version: '1.0',
+		version: '1.1',
 		patterns: [
 			[ '~E', 'Ə' ],
 			[ '~e', 'ə' ],
@@ -19,6 +19,7 @@
 			[ '~l', 'ɬ' ],
 			[ '~X', 'X̣' ],
 			[ '~x', 'x̣' ],
+			[ '~\\\'', '’' ],
 			[ '~\\?', 'ʔ' ]
 		]
 	};

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -873,7 +873,7 @@ var palochkaVariants = {
 		description: 'Chinook Jargon tilde test',
 		inputmethod: 'chn-tilde',
 		tests: [
-			{ input: '~E~e~H~h~L~l~X~x~?', output: 'ƏəʰʰꞭɬX̣x̣ʔ', description: 'Chinook Jargon ƏəʰʰꞭɬX̣x̣ʔ' }
+			{ input: '~E~e~H~h~L~l~X~x~?~\'', output: 'ƏəʰʰꞭɬX̣x̣ʔ’', description: 'Chinook Jargon ƏəʰʰꞭɬX̣x̣ʔ’' }
 		]
 	},
 	{


### PR DESCRIPTION
Downstream bug:
https://phabricator.wikimedia.org/T360547