### PR TITLE
Add keyboard for Krio (kri)

### DIFF
--- a/rules/kri/kri-tilde.js
+++ b/rules/kri/kri-tilde.js
@@ -1,0 +1,27 @@
+( function ( $ ) {
+	'use strict';
+
+	var kriTilde = {
+		id: 'kri-tilde',
+		name: 'Krio tilde',
+		description: 'Krio input keyboard',
+		date: '2024-09-23',
+		URL: 'https://github.com/wikimedia/jquery.ime',
+		author: 'Amir E. Aharoni',
+		license: 'GPLv3',
+		version: '1.0',
+		patterns: [
+			[ '~E', 'Ɛ' ],
+			[ '~e', 'ɛ' ],
+			[ '~N', 'Ŋ' ],
+			[ '~n', 'ŋ' ],
+			[ '~O', 'Ɔ' ],
+			[ '~o', 'ɔ' ],
+			[ '~\\\\', '\u0300' ], // Combining grave
+			[ '~/', '\u0301' ], // Combining acute
+			[ '~\\^', '\u0302' ] // Combining circumflex
+		]
+	};
+
+	$.ime.register( kriTilde );
+}( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -516,6 +516,10 @@
 			name: 'Kanuri tilde',
 			source: 'rules/kr/kr-tilde.js'
 		},
+		'kri-tilde': {
+			name: 'Krio tilde',
+			source: 'rules/kri/kri-tilde.js'
+		},
 		'ky-cyrl-alt': {
 			name: 'Кыргыз Alt',
 			source: 'rules/ky/ky-cyrl-alt.js'
@@ -1381,6 +1385,10 @@
 		kr: {
 			autonym: 'kanuri',
 			inputmethods: [ 'kr-tilde' ]
+		},
+		kri: {
+			autonym: 'Krio',
+			inputmethods: [ 'kri-tilde' ]
 		},
 		ks: {
 			autonym: 'कॉशुर / کٲشُر',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -3906,6 +3906,14 @@ var palochkaVariants = {
 		]
 	},
 	{
+		description: 'Krio tilde test',
+		inputmethod: 'kri-tilde',
+		tests: [
+			{ input: '~E~e~N~n~O~o', output: 'ƐɛŊŋƆɔ', description: 'Krio tilde ƐɛŊŋƆɔ' },
+			{ input: 'a~\\e~/i~^', output: 'àéî', description: 'Krio tilde àéî' }
+		]
+	},
+	{
 		description: 'Kashmiri InScript test',
 		inputmethod: 'ks-inscript',
 		tests: [


### PR DESCRIPTION
It's support in core MediaWiki and active
in translatewiki, so it should be supported
in jquery.ime, too. I somehow missed adding
it when I added all the African languages in 2019.