### PR TITLE
Clean up Shan input method

### DIFF
--- a/rules/shn/shn-standard.js
+++ b/rules/shn/shn-standard.js
@@ -2,7 +2,7 @@
 	'use strict';
 
 	var shn = {
-		id: 'my-shn',
+		id: 'shn-standard',
 		name: 'လွၵ်းမိုဝ်းလိၵ်ႈတႆး',
 		description: 'Shan Standard Keyboard per SIIT',
 		date: '2022-09-15',
@@ -11,8 +11,8 @@
 		license: 'GPLv3',
 		version: '1.0',
 		patterns: [
-			//Basic Cosonants
-            		[ 'u', '', 'ၵ' ],
+			// Basic Cosonants
+			[ 'u', '', 'ၵ' ],
 			[ 'c', '', 'ၶ' ],
 			[ 'C', '', 'ꧠ' ],
 			[ 'i', '', 'င' ],
@@ -44,7 +44,8 @@
 			[ 't', '', 'ဢ' ],
 			[ 'I', '', 'ရ' ],
 			[ 'O', '', 'သ' ],
-            		// Signs
+
+			// Signs
 			[ 'm', '', 'ၢ' ],
 			[ 'g', '', 'ွ' ],
 			[ 'd', '', 'ိ' ],
@@ -59,10 +60,12 @@
 			[ 'f', '','်' ],
 			[ 'F', '','ႂ်' ],
 			[ 'M', '', 'ႃ' ],
-            		//Punctuation
+
+			// Punctuation
 			[ '\\>', '', '။' ],
 			[ '\\<', '', '၊' ],
-            		//Signs 
+
+			// Signs
 			[ 'A', '', 'ဵ' ],
 			[ 'K', '', 'ꧦ' ],
 			[ 'L', '', 'ႊ' ],
@@ -81,7 +84,9 @@
 			[ '\\[','', '[' ],
 			[ '\\}', '', '}' ],
 			[ '\\\\', '', '\'' ],
-            		//Shan Digits As Jquery IME doesn't support Alt+Key, Shift+ALt+Key, Tide Key+Key will use Roman Digit only for now.
+
+			// Shan digits, as jquery.ime doesn't support Alt+Key,
+			// Shift+ALt+Key, Tide Key+Key will use Roman Digit only for now
 			[ '0', '', '0' ],
 			[ '1', '', '1' ],
 			[ '2', '', '2' ],

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -714,10 +714,6 @@
 			name: 'မြန်မာ၃ လက်ကွက်',
 			source: 'rules/my/my-mm3.js'
 		},
-		'my-shn': {
-			name: 'လွၵ်းမိုဝ်းလိၵ်ႈတႆး',
-			source: 'rules/my/my-shn.js'
-		},
 		'my-xkb': {
 			name: 'မြန်မာဘာသာ xkb',
 			source: 'rules/my/my-xkb.js'
@@ -905,6 +901,10 @@
 		'sg-tilde': {
 			name: 'Sängö',
 			source: 'rules/sg/sg-tilde.js'
+		},
+		'shn-standard': {
+			name: 'လွၵ်းမိုဝ်းလိၵ်ႈတႆး',
+			source: 'rules/shn/shn-standard.js'
 		},
 		'si-singlish': {
 			name: 'සිංග්ලිෂ්',
@@ -1576,11 +1576,7 @@
 		},
 		my: {
 			autonym: 'မြန်မာ',
-			inputmethods: [ 'my-mm3', 'my-xkb', 'my-shn' ]
-		},
-		shn: {
-			autonym: 'လိၵ်ႈတႆး',
-			inputmethods: [ 'my-shn' ]
+			inputmethods: [ 'my-mm3', 'my-xkb' ]
 		},
 		naq: {
 			autonym: 'Khoekhoegowab',
@@ -1697,6 +1693,10 @@
 		shi: {
 			autonym: 'ⵜⴰⵛⵍⵃⵉⵜ',
 			inputmethods: [ 'ber-tfng' ]
+		},
+		shn: {
+			autonym: 'လိၵ်ႈတႆး',
+			inputmethods: [ 'shn-standard' ]
 		},
 		si: {
 			autonym: 'සිංහල',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -622,7 +622,7 @@ var palochkaVariants = {
 			{ input: [ [ '7', true ] ], output: '᯿', description: 'Simalungun keyboard - alt-7 - bindu pangolat' }
 		]
 	},
-	{		
+	{
     description: 'Batak Mandailing transliteration test',
 		inputmethod: 'btm-transliteration',
 		tests: [
@@ -5080,9 +5080,9 @@ var palochkaVariants = {
 			{ input: 'ujdkqdkygonf>', output: 'ကြိုဆိုပါသည်။', description: 'Myanmar mm3 ကြိုဆိုပါသည်။' }
 		]
 	},
-		{
+	{
 		description: 'Shan Keyboard Test',
-		inputmethod: 'my-shn',
+		inputmethod: 'shn-standard',
 		tests: [
 			{ input: 'qmrf:wlnf:', output: 'ၸၢမ်းတူၺ်း', description: 'ၸၢမ်းတူၺ်းလွၵ်းမိုဝ်းတႆးၶႃႈ' }
 		]


### PR DESCRIPTION
Follow-up to #700.

* Rename the "my-shn" identifier to "shn-standard": these identifiers usually begin with the language, and continue with the name of the keyboard. The language here is "shn", not "my".
* Alphabetical order of input methods, language codes, and test fixtures.
* Whitespace clean-up in the rules file.