### PR TITLE
Clean up Korean input method

### DIFF
--- a/rules/ko/ko-rr.js
+++ b/rules/ko/ko-rr.js
@@ -33,7 +33,7 @@
 		[ '([ᅡ-ᅵ])h', '$1ᇂ' ],
 
 		// Use space, hyphen, and apostrophe to disambiguate
-		// Do nothing, combineJamo will do the work 
+		// Do nothing, combineJamo will do the work
 		[ '([\- \'])', '$1'],
 
 		// Syllable initials
@@ -62,7 +62,7 @@
 		[ 'T', 'ᄐ' ],
 		[ 'p', 'ᄑ' ],
 		[ 'h', 'ᄒ' ],
-		
+
 		// Vowels
 		// Vowels without consontant initial must have ᄋ prepended
 		// [^ᄀ-ᄒ]|^ matches the start character or anything but an initial consonant
@@ -106,7 +106,7 @@
 	];
 
 	var koreanRR = {
-		id: 'kor-rr',
+		id: 'ko-rr',
 		name: 'Korean Revised Romanization',
 		description: 'Transliteration using Korean revised romanization',
 		date: '2023-02-04',
@@ -117,7 +117,7 @@
 		maxKeyLength: 4,
 		contextLength: 1,
 
-		// This function mirrors the normal behavior in jquery.ime.js, 
+		// This function mirrors the normal behavior in jquery.ime.js,
 		// except it combines jamo when a new syllable starts
 		// This version does not support context rules, but we don't need them
 		patterns: function(input, context) {
@@ -135,7 +135,7 @@
 				// Input string match test
 				if ( regex.test( input ) ) {
 					result = input.replace(regex, replacement);
-					
+
 					// This regex matches jamo that form a syllable so they can be combined
 					var jamoRegex = /([ᄀ-ᄒ])([ᅡ-ᅵ])([ᆨ-ᇂ])?([ᄀ-ᄒ]|[\- '])(.*)$/;
 					if (jamoRegex.test(result)) {

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -548,9 +548,9 @@
 			name: 'ಲಿಪ್ಯಂತರಣ',
 			source: 'rules/kn/kn-transliteration.js'
 		},
-		'kor-rr': {
+		'ko-rr': {
 			name: 'Korean Revised Romanization',
-			source: 'rules/kor/kor-rr.js'
+			source: 'rules/ko/ko-rr.js'
 		},
 		'kr-tilde': {
 			name: 'Kanuri tilde',
@@ -1466,9 +1466,9 @@
 			autonym: 'ಕನ್ನಡ',
 			inputmethods: [ 'kn-transliteration', 'kn-inscript', 'kn-kgp', 'kn-inscript2' ]
 		},
-		kor: {
+		ko: {
 			autonym: '한국어',
-			inputmethods: [ 'kor-rr' ]
+			inputmethods: [ 'ko-rr' ]
 		},
 		kr: {
 			autonym: 'kanuri',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -4186,7 +4186,7 @@ var palochkaVariants = {
 	},
 	{
 		description: 'Korean RR test',
-		inputmethod: 'kor-rr',
+		inputmethod: 'ko-rr',
 		tests: [
 			// Note that RR is meant to romanize from hangul to latin script, but not
 			// the other way around, so there are some instances where the keystrokes


### PR DESCRIPTION
Follow-up to #716.

* Rename the "kor-rr" identifier to "ko-rr" and "kor" to "ko": We use two-letter language codes when they are available.
* Whitespace clean-up.