### PR TITLE
Add a tilde keyboard for the Fur language (fvr)

### DIFF
--- a/rules/fvr/fvr-tilde.js
+++ b/rules/fvr/fvr-tilde.js
@@ -1,0 +1,30 @@
+( function ( $ ) {
+	'use strict';
+
+	var fvrTilde = {
+		id: 'fvr-tilde',
+		name: 'fvr-tilde',
+		description: 'Fur tilde keyboard',
+		date: '2024-10-31',
+		URL: 'https://github.com/wikimedia/jquery.ime',
+		author: 'Amir E. Aharoni',
+		license: 'GPLv3',
+		version: '1.0',
+		patterns: [
+			[ '~A', 'A\u0331' ], // A with combining macron below
+			[ '~a', 'a\u0331' ], // A with combining macron below
+			[ '~I', 'Ɨ' ],
+			[ '~i', 'ɨ' ],
+			[ '~N', 'Ŋ' ],
+			[ '~n', 'ŋ' ],
+			[ '~U', 'Ʉ' ],
+			[ '~u', 'ʉ' ],
+			[ '~/', '\u0301' ], // Combining acute accent
+			[ '~\\^', '\u0302' ], // Combining circumflex accent
+			[ '~v', '\u030C' ], // Combining caron
+			[ '~_', '\u0331' ] // Combining macron below
+		]
+	};
+
+	$.ime.register( fvrTilde );
+}( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -344,6 +344,10 @@
 			name: 'Fon Tilde',
 			source: 'rules/fon/fon-tilde.js'
 		},
+		'fvr-tilde': {
+			name: 'Fur Tilde',
+			source: 'rules/fvr/fvr-tilde.js'
+		},
 		'gaa-cqx': {
 			name: 'Ga CQX replacement',
 			source: 'rules/gaa/gaa-cqx.js'
@@ -1333,6 +1337,10 @@
 		fon: {
 			autonym: 'Fon',
 			inputmethods: [ 'fon-tilde' ]
+		},
+		fvr: {
+			autonym: 'poor’íŋ belé’ŋ',
+			inputmethods: [ 'fvr-tilde' ]
 		},
 		fonipa: {
 			autonym: 'International Phonetic Alphabet',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -2103,6 +2103,16 @@ var palochkaVariants = {
 		]
 	},
 	{
+		description: 'Fur tilde test',
+		inputmethod: 'fvr-tilde',
+		tests: [
+			{ input: 'appa~^k~u~no APPA~^K~U~NO', output: 'appâkʉŋo APPÂKɄŊO', description: 'Fur tilde appâkʉŋo' },
+			{ input: 'ta~_b~u~/~n T~AB~U~/~N', output: 'ta̱bʉ́ŋ TA̱BɄ́Ŋ', description: 'Fur tilde ta̱bʉ́ŋ' },
+			{ input: 'k~akk~i~/ KA~_KK~I~/', output: 'ka̱kkɨ́ KA̱KKƗ́', description: 'Fur tilde ka̱kkɨ́' },
+			{ input: 'da~vy DA~vY', output: 'dǎy DǍY', description: 'Fur tilde da~v' }
+		]
+	},
+	{
 		description: 'Ga CQX test',
 		inputmethod: 'gaa-cqx',
 		tests: [


### PR DESCRIPTION
The orthography is based on the proposal in
"Occasional Papers in the Study of Sudanese Languages No. 9", page 24.
It was confirmed by the Wikimedia Incubator authors as the thing they actually use for writing.