### PR TITLE
Change internal ids of methods from language codes

### DIFF
--- a/rules/chr/chr-translit.js
+++ b/rules/chr/chr-translit.js
@@ -1,8 +1,8 @@
 ( function ( $ ) {
 	'use strict';
 
-	var chr = {
-		id: 'chr',
+	var chrTranslit = {
+		id: 'chr-translit',
 		name: 'Cherokee',
 		description: 'Typing Cherokee syllabary from English letters',
 		date: '2023-01-14',
@@ -129,5 +129,5 @@
 		]
 	};
 
-	$.ime.register( chr );
+	$.ime.register( chrTranslit );
 }( jQuery ) );

--- a/rules/mh/mh-replace.js
+++ b/rules/mh/mh-replace.js
@@ -9,8 +9,8 @@
 ( function ( $ ) {
 	'use strict';
 
-	var mh = {
-		id: 'mh',
+	var mhReplace = {
+		id: 'mh-replace',
 		name: 'Kajin M̧ajeļ',
 		description: 'Marshallese Language',
 		date: '2013-03-29',
@@ -39,5 +39,5 @@
 		]
 	};
 
-	$.ime.register( mh );
+	$.ime.register( mhReplace );
 }( jQuery ) );

--- a/rules/mnc/mnc-scripts.js
+++ b/rules/mnc/mnc-scripts.js
@@ -1,8 +1,8 @@
 ( function ( $ ) {
 	'use strict';
 
-	var manchu = {
-		id: 'mnc',
+	var manchuScripts = {
+		id: 'mnc-scripts',
 		name: 'Manchu Scripts',
 		description: 'Manchu Scripts',
 		date: '2014-4-22',
@@ -108,5 +108,5 @@
 		]
 	};
 
-	$.ime.register( manchu );
+	$.ime.register( manchuScripts );
 }( jQuery ) );

--- a/rules/sjo/sjo-scripts.js
+++ b/rules/sjo/sjo-scripts.js
@@ -1,8 +1,8 @@
 ( function ( $ ) {
 	'use strict';
 
-	var sibe = {
-		id: 'sjo',
+	var sjoScripts = {
+		id: 'sjo-scripts',
 		name: 'Sibe Scripts',
 		description: 'Sibe Scripts',
 		date: '2014-4-22',
@@ -108,5 +108,5 @@
 		]
 	};
 
-	$.ime.register( sibe );
+	$.ime.register( sjoScripts );
 }( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -208,9 +208,9 @@
 			name: 'Chinook wawa tilde',
 			source: 'rules/chn/chn-tilde.js'
 		},
-		'chr': {
+		'chr-translit': {
 			name: 'Cherokee Transliteration',
-			source: 'rules/chr/chr.js'
+			source: 'rules/chr/chr-translit.js'
 		},
 		'ckb-transliteration-arkbd': {
 			name: 'باشووری',
@@ -634,9 +634,9 @@
 			name: 'Malagasy tilde',
 			source: 'rules/mg/mg-tilde.js'
 		},
-		'mh': {
+		'mh-replace': {
 			name: 'Kajin M̧ajeļ',
-			source: 'rules/mh/mh.js'
+			source: 'rules/mh/mh-replace.js'
 		},
 		'ml-inscript': {
 			name: 'ഇൻസ്ക്രിപ്റ്റ്',
@@ -670,9 +670,9 @@
 			name: 'Traditional Mongolian Ali-gali',
 			source: 'rules/mn/mn-tradali.js'
 		},
-		'mnc': {
+		'mnc-scripts': {
 			name: 'ᠮᠠᠨᠵᡠ',
-			source: 'rules/mnc/mnc.js'
+			source: 'rules/mnc/mnc-scripts.js'
 		},
 		'mnc-ali': {
 			name: 'Manchu Ali-gali',
@@ -918,9 +918,9 @@
 			name: 'විජේසේකර',
 			source: 'rules/si/si-wijesekara.js'
 		},
-		'sjo': {
+		'sjo-scripts': {
 			name: 'ᠰᡞᠪᡝ',
-			source: 'rules/sjo/sjo.js'
+			source: 'rules/sjo/sjo-scripts.js'
 		},
 		'sk-kbd': {
 			name: 'Štandardná',
@@ -1240,7 +1240,7 @@
 		},
 		chr: {
 			autonym: 'ᏣᎳᎩ',
-			inputmethods: [ 'chr' ]
+			inputmethods: [ 'chr-translit' ]
 		},
 		ckb: {
 			autonym: 'کوردی',
@@ -1556,7 +1556,7 @@
 		},
 		mh: {
 			autonym: 'Kajin M̧ajeļ',
-			inputmethods: [ 'mh' ]
+			inputmethods: [ 'mh-replace' ]
 		},
 		ml: {
 			autonym: 'മലയാളം',
@@ -1568,7 +1568,7 @@
 		},
 		mnc: {
 			autonym: 'ᠮᠠᠨᠵᡠ',
-			inputmethods: [ 'mnc', 'mnc-ali' ]
+			inputmethods: [ 'mnc-scripts', 'mnc-ali' ]
 		},
 		mni: {
 			autonym: 'Manipuri',
@@ -1716,7 +1716,7 @@
 		},
 		sjo: {
 			autonym: 'ᠰᡞᠪᡝ',
-			inputmethods: [ 'sjo' ]
+			inputmethods: [ 'sjo-scripts' ]
 		},
 		sk: {
 			autonym: 'Slovenčina',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -1172,7 +1172,7 @@ var palochkaVariants = {
 	},
 	{
 		description: 'Cherokee transliteration test',
-		inputmethod: 'chr',
+		inputmethod: 'chr-translit',
 		tests: [
 			{ input: 'nah\'na', output: 'ᏀᎾ', description: 'Cherokee nah\'na -> ᏀᎾ' },
 			{ input: 'na\'hna', output: 'ᎾᎿ', description: 'Cherokee na\'hna -> ᎾᎿ' },
@@ -4698,7 +4698,7 @@ var palochkaVariants = {
 	},
 	{
 		description: 'Kajin M̧ajeļ (Marshallese) test',
-		inputmethod: 'mh',
+		inputmethod: 'mh-replace',
 		tests: [
 			{ input: 'Y', output: 'Ū', description: 'Y for Ū in Marshallese' },
 			{ input: 'S', output: 'Ā', description: 'S for Ā in Marshallese' },
@@ -4781,9 +4781,9 @@ var palochkaVariants = {
 	},
 	{
 		description: 'Manchu mnc test',
-		inputmethod: 'mnc',
+		inputmethod: 'mnc-scripts',
 		tests: [
-			{ input: 'LWE', output: 'ᡀᠸᠧ', description: 'Manchu mnc' }
+			{ input: 'LWE', output: 'ᡀᠸᠧ', description: 'Manchu mnc-scripts' }
 		]
 	},
 	{
@@ -6010,10 +6010,10 @@ var palochkaVariants = {
 		]
 	},
 	{
-		description: 'Xibe sjo test',
-		inputmethod: 'sjo',
+		description: 'Xibe sjo-scripts test',
+		inputmethod: 'sjo-scripts',
 		tests: [
-			{ input: 'WER', output: 'ᠸᠧᡰ', description: 'Xibe sjo 〈ᠴᠣᡝ〉' }
+			{ input: 'WER', output: 'ᠸᠧᡰ', description: 'Xibe sjo-scripts 〈ᠴᠣᡝ〉' }
 		]
 	},
 	{


### PR DESCRIPTION
Some input methods had internal ids that were
the same as language codes. This was problematic,
for example, for reasons described in downstream task
https://phabricator.wikimedia.org/T378865

Here, they are all changed to unique ids
that don't conflict with language codes.