### PR TITLE
Add Mansi backslash keyboard

### DIFF
--- a/rules/mns/mns-backslash.js
+++ b/rules/mns/mns-backslash.js
@@ -1,0 +1,40 @@
+( function ( $ ) {
+	'use strict';
+
+	var mnsBackslash = {
+		id: 'mns-backslash',
+		name: 'mns-backslash',
+		description: 'Mansi backslash keyboard',
+		date: '2024-11-05',
+		URL: 'https://github.com/wikimedia/jquery.ime',
+		author: 'Amir E. Aharoni',
+		license: 'GPLv3',
+		version: '1.0',
+		patterns: [
+			[ '\\\\А', 'А̄' ],
+			[ '\\\\а', 'а̄' ],
+			[ '\\\\Е', 'Е̄' ],
+			[ '\\\\е', 'е̄' ],
+			[ '\\\\Ё', 'Ё̄' ],
+			[ '\\\\ё', 'ё̄' ],
+			[ '\\\\И', 'Ӣ' ],
+			[ '\\\\и', 'ӣ' ],
+			[ '\\\\Н', 'Ӈ' ],
+			[ '\\\\н', 'ӈ' ],
+			[ '\\\\О', 'О̄' ],
+			[ '\\\\о', 'о̄' ],
+			[ '\\\\У', 'Ӯ' ],
+			[ '\\\\у', 'ӯ' ],
+			[ '\\\\Ы', 'Ы̄' ],
+			[ '\\\\ы', 'ы̄' ],
+			[ '\\\\Э', 'Э̄' ],
+			[ '\\\\э', 'э̄' ],
+			[ '\\\\Ю', 'Ю̄' ],
+			[ '\\\\ю', 'ю̄' ],
+			[ '\\\\Я', 'Я̄' ],
+			[ '\\\\я', 'я̄' ]
+		]
+	};
+
+	$.ime.register( mnsBackslash );
+}( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -682,6 +682,10 @@
 			name: 'ইনস্ক্ৰিপ্ট ২',
 			source: 'rules/mni/mni-inscript2.js'
 		},
+		'mns-backslash': {
+			name: 'Mansi backslash',
+			source: 'rules/mns/mns-backslash.js'
+		},
 		'mnw-simplified-anonta': {
 			name: 'Mon Simplified Anonta',
 			source: 'rules/mnw/mnw-simplified-anonta.js'
@@ -1573,6 +1577,10 @@
 		mni: {
 			autonym: 'Manipuri',
 			inputmethods: [ 'mni-inscript2' ]
+		},
+		mns: {
+			autonym: 'ма̄ньси',
+			inputmethods: [ 'mns-backslash' ]
 		},
 		mnw: {
 			autonym: 'ဘာသာမန်',

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -4828,6 +4828,13 @@ var palochkaVariants = {
 		]
 	},
 	{
+		description: 'Mansi backslash test',
+		inputmethod: 'mns-backslash',
+		tests: [
+			{ input: '\\А\\а\\Е\\е\\Ё\\ё\\И\\и\\Н\\н\\О\\о\\У\\у\\Ы\\ы\\Э\\э\\Ю\\ю\\Я\\я', output: 'А̄а̄Е̄е̄Ё̄ё̄ӢӣӇӈО̄о̄ӮӯЫ̄ы̄Э̄э̄Ю̄ю̄Я̄я̄', description: 'Mansi backslash test' }
+		]
+	},
+	{
 		description: 'Mon Simplified Anonta test',
 		inputmethod: 'mnw-simplified-anonta',
 		tests: [


### PR DESCRIPTION
Using backslash instead of tilde because
tilde is usually not available on Russian keyboards.

Downstream task:
https://phabricator.wikimedia.org/T375944