### PR TITLE
List zh-pinyin-transliteration IME in zh-* languages

### DIFF
--- a/rules/zh/zh-latn-pinyin-transliteration.js
+++ b/rules/zh/zh-latn-pinyin-transliteration.js
@@ -1,10 +1,10 @@
 ( function ( $ ) {
 	'use strict';
 
-	var zhPinyinTransliteration = {
-		id: 'zh-pinyin-transliteration',
-		name: '拼音符号输入法',
-		description: 'Mandarin PinYin Transliteration input method',
+	var zhLatnPinyinTransliteration = {
+		id: 'zh-latn-pinyin-transliteration',
+		name: '拼音符号输入法 / 拼音符號輸入法',
+		description: 'Mandarin Hanyu Pinyin Transliteration input method',
 		date: '2018-12-28',
 		URL: 'http://github.com/wikimedia/jquery.ime',
 		author: 'Yuping Zuo',
@@ -56,5 +56,5 @@
 		]
 	};
 
-	$.ime.register( zhPinyinTransliteration );
+	$.ime.register( zhLatnPinyinTransliteration );
 }( jQuery ) );

--- a/src/jquery.ime.inputmethods.js
+++ b/src/jquery.ime.inputmethods.js
@@ -1078,9 +1078,9 @@
 			name: 'Yorùbá tilde',
 			source: 'rules/yo/yo-tilde.js'
 		},
-		'zh-pinyin-transliteration': {
-			name: '拼音符号输入法',
-			source: 'rules/zh/zh-pinyin-transliteration.js'
+		'zh-latn-pinyin-transliteration': {
+			name: '拼音符号输入法 / 拼音符號輸入法',
+			source: 'rules/zh/zh-latn-pinyin-transliteration.js'
 		}
 	} );
 	/* eslint-disable quote-props */
@@ -1856,7 +1856,39 @@
 		},
 		zh: {
 			autonym: '中文',
-			inputmethods: [ 'zh-pinyin-transliteration' ]
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-cn': {
+			autonym: '中文（中国大陆）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-hans': {
+			autonym: '中文（简体）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-hant': {
+			autonym: '中文（繁體）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-hk': {
+			autonym: '中文（香港）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-mo': {
+			autonym: '中文（澳門）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-my': {
+			autonym: '中文（马来西亚）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-sg': {
+			autonym: '中文（新加坡）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
+		},
+		'zh-tw': {
+			autonym: '中文（臺灣）',
+			inputmethods: [ 'zh-latn-pinyin-transliteration' ]
 		}
 	} );
 }( jQuery ) );

--- a/test/jquery.ime.test.fixtures.js
+++ b/test/jquery.ime.test.fixtures.js
@@ -7189,17 +7189,17 @@ var palochkaVariants = {
 		]
 	},
 	{
-		description: 'Chinese Pinyin test',
-		inputmethod: 'zh-pinyin-transliteration',
+		description: 'Mandarin Hanyu Pinyin test',
+		inputmethod: 'zh-latn-pinyin-transliteration',
 		tests: [
-			{ input: 'wen2', output: 'wén', description: 'Chinese Pinyin wén' },
-			{ input: 'lv3', output: 'lǚ', description: 'Chinese Pinyin lǚ' },
-			{ input: 'hua4', output: 'huà', description: 'Chinese Pinyin huà' },
-			{ input: 'liou2', output: 'liú', description: 'Chinese Pinyin liú' },
-			{ input: 'jv', output: 'ju', description: 'Chinese Pinyin ju' },
-			{ input: 'xiao4', output: 'xiào', description: 'Chinese Pinyin xiào' },
-			{ input: 'jv1', output: 'jū', description: 'Chinese Pinyin jū' },
-			{ input: 'wang3', output: 'wǎng', description: 'Chinese Pinyin wǎng' }
+			{ input: 'wen2', output: 'wén', description: 'Mandarin Hanyu Pinyin wén' },
+			{ input: 'lv3', output: 'lǚ', description: 'Mandarin Hanyu Pinyin lǚ' },
+			{ input: 'hua4', output: 'huà', description: 'Mandarin Hanyu Pinyin huà' },
+			{ input: 'liou2', output: 'liú', description: 'Mandarin Hanyu Pinyin liú' },
+			{ input: 'jv', output: 'ju', description: 'Mandarin Hanyu Pinyin ju' },
+			{ input: 'xiao4', output: 'xiào', description: 'Mandarin Hanyu Pinyin xiào' },
+			{ input: 'jv1', output: 'jū', description: 'Mandarin Hanyu Pinyin jū' },
+			{ input: 'wang3', output: 'wǎng', description: 'Mandarin Hanyu Pinyin wǎng' }
 		]
 	}
 ];


### PR DESCRIPTION
Also renamed from `zh-pinyin-transliteration` to `zh-latn-pinyin-transliteration` to reflect the input method is for `zh-latn-pinyin`, not `zh-hans` or `zh-hant`.

Bug: #813
Change-Id: Ib9bd97f48845b4f3dc7a47d0d55fccb9b734e0f5