### PR TITLE
updated url links for input methods with their various mediawiki docu…

### DIFF
--- a/rules/ach/ach-tilde.js
+++ b/rules/ach/ach-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ach-tilde',
 		description: 'Acholi tilde keyboard',
 		date: '2024-09-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ach-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/af/af-tilde.js
+++ b/rules/af/af-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Afrikaans tilde',
 		description: 'Afrikaans tilde',
 		date: '2019-04-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/af-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ak/ak-tilde.js
+++ b/rules/ak/ak-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Akan tilde',
 		description: 'Akan tilde',
 		date: '2019-05-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ak-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/am/am-transliteration.js
+++ b/rules/am/am-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Amharic Transliteration',
 		description: 'Amharic Transliteration',
 		date: '2012-09-09',
-		URL: 'http://am.wikipedia.org/wiki/%E1%8A%A5%E1%88%AD%E1%8B%B3%E1%89%B3:%E1%8A%A2%E1%89%B5%E1%8B%AE%E1%8D%92%E1%8A%AD_%E1%88%B4%E1%88%AB',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/am-transliteration',
 		author: 'Elfalem [[User:Elfalem]])',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ann/ann-tilde.js
+++ b/rules/ann/ann-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ann-tilde',
 		description: 'Obolo input keyboard',
 		date: '2020-11-03',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ann-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/ar/ar-kbd.js
+++ b/rules/ar/ar-kbd.js
@@ -6,7 +6,7 @@
 		name: 'kbd',
 		description: 'PC Arabic keyboard layout',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ar-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/as/as-avro.js
+++ b/rules/as/as-avro.js
@@ -6,7 +6,7 @@
 		name: 'অভ্ৰ',
 		description: 'Assamese Avro layout based on Bengali Avro input method',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/as-avro',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/as/as-bornona.js
+++ b/rules/as/as-bornona.js
@@ -6,7 +6,7 @@
 		name: 'বৰ্ণনা',
 		description: 'Bornona input method for Assamese',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/as-bornona',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/as/as-inscript.js
+++ b/rules/as/as-inscript.js
@@ -6,7 +6,7 @@
 		name: 'ইনস্ক্ৰিপ্ট',
 		description: 'InScript input method for Assamese according to CDAC\'s Enhanced InScript Keyboard Layout 5.2',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/as-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/as/as-inscript2.js
+++ b/rules/as/as-inscript2.js
@@ -6,7 +6,7 @@
 		name: 'ইনস্ক্ৰিপ্ট ২',
 		description: 'Enhanced InScript keyboard for Assamese language',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/as-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/as/as-phonetic.js
+++ b/rules/as/as-phonetic.js
@@ -6,7 +6,7 @@
 		name: 'phonetic',
 		description: 'Phonetic keyboard for Assamese script',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/as-phonetic',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/as/as-transliteration.js
+++ b/rules/as/as-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'প্ৰতিৰূপান্তৰণ',
 		description: 'Assamese Transliteration input method',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/as-transliteration',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/azb/azb-kbd.js
+++ b/rules/azb/azb-kbd.js
@@ -6,7 +6,7 @@
 		name: 'تۆرکجه',
 		description: 'South Azerbaijani Keyboard Layout',
 		date: '2015-05-02',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/azb-kbd',
 		author: 'Mjbmr',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bas/bas-tilde.js
+++ b/rules/bas/bas-tilde.js
@@ -6,7 +6,7 @@
 		name: 'bas-tilde',
 		description: 'Basaa tilde keyboard',
 		date: '2021-03-31',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bas-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bbc/bbc-transliteration.js
+++ b/rules/bbc/bbc-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Toba Transliteration',
 		description: 'QWERTY-based Batak Toba transliteration',
 		date: '2014-04-20',
-		URL: 'http://evertype.com/fonts/batak/',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bbc-transliteration',
 		author: 'design by Michael Everson, implementation by Amir E. Aharoni and Benny Lin',
 		version: '1.1',
 		patterns: [

--- a/rules/bci/bci-tilde.js
+++ b/rules/bci/bci-tilde.js
@@ -6,7 +6,7 @@
 		name: 'bci-tilde',
 		description: 'Baoulé tilde keyboard',
 		date: '2020-06-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bci-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/be/be-kbd.js
+++ b/rules/be/be-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Belarusian kbd',
 		description: 'Belarusian keyboard layout',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/be-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/be/be-latin.js
+++ b/rules/be/be-latin.js
@@ -6,7 +6,7 @@
 		name: 'Belarusian Łacinka',
 		description: 'Belarusian Latin alphabet input method',
 		date: '2012-11-06',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/be-latin',
 		author: 'Pavel Selitskas',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/be/be-transliteration.js
+++ b/rules/be/be-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Belarusian Transliteration',
 		description: 'Belarusian transliteration per Belarusian winkeys',
 		date: '2012-11-06',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/be-transliteration',
 		author: 'Pavel Selitskas',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ber/ber-tfng.js
+++ b/rules/ber/ber-tfng.js
@@ -6,7 +6,7 @@
 		name: 'Tifinagh Transliteration',
 		description: 'Transliteration input method for Tifinagh script',
 		date: '2012-10-10',
-		URL: 'http://www.ircam.ma/fr/index.php?soc=telec&rd=2',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ber-tfng',
 		author: '',
 		license: '',
 		version: '1.0',

--- a/rules/bfa/bfa-tilde.js
+++ b/rules/bfa/bfa-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Bari tilde',
 		description: 'Bari tilde',
 		date: '2022-12-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bfa-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bgn/bgn-kbd.js
+++ b/rules/bgn/bgn-kbd.js
@@ -6,7 +6,7 @@
 		name: 'روچ کپتین بلوچی',
 		description: 'Western Baluchi Keyboard Layout',
 		date: '2015-03-11',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bgn-kbd',
 		author: 'Mjbmr',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bkm/bkm-tilde.js
+++ b/rules/bkm/bkm-tilde.js
@@ -6,7 +6,7 @@
 		name: 'bkm-tilde',
 		description: 'Kom tilde keyboard',
 		date: '2021-03-31',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bkm-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bm/bm-tilde.js
+++ b/rules/bm/bm-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Bamanankan tilde',
 		description: 'Bamanankan tilde',
 		date: '2019-05-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bm-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bn/bn-avro.js
+++ b/rules/bn/bn-avro.js
@@ -6,7 +6,7 @@
 		name: 'অভ্র',
 		description: 'Bengali Avro input method',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bn-avro',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bn/bn-inscript.js
+++ b/rules/bn/bn-inscript.js
@@ -6,7 +6,7 @@
 		name: 'ইনস্ক্ৰিপ্ট',
 		description: 'Bengali InScript input method',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bn-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bn/bn-inscript2.js
+++ b/rules/bn/bn-inscript2.js
@@ -6,7 +6,7 @@
 		name: 'ইনস্ক্ৰিপ্ট ২',
 		description: 'Enhanced InScript keyboard for Bengali language',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bn-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bn/bn-nkb.js
+++ b/rules/bn/bn-nkb.js
@@ -6,7 +6,7 @@
 		name: 'Jatiyo Keyboard',
 		description: 'Bengali Jatiyo Keyboard input method',
 		date: '2012-10-10',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bn-nkb',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bn/bn-probhat.js
+++ b/rules/bn/bn-probhat.js
@@ -6,7 +6,7 @@
 		name: 'Bengali Probhat',
 		description: 'Bengali Probhat input method for Bengali',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bn-probhat',
 		author: 'Nasir Khan Saikat',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bom/bom-tilde.js
+++ b/rules/bom/bom-tilde.js
@@ -6,7 +6,7 @@
 		name: 'bom-tilde',
 		description: 'Bèrom tilde keyboard',
 		date: '2022-12-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bom-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/brx/brx-inscript.js
+++ b/rules/brx/brx-inscript.js
@@ -6,7 +6,7 @@
 		name: 'Bodo Inscript',
 		description: 'Bodo Inscript input method',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/brx-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/bwr/bwr-tilde.js
+++ b/rules/bwr/bwr-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Bura tilde',
 		description: 'Bura tilde keyboard',
 		date: '2022-08-14',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/bwr-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/chn/chn-tilde.js
+++ b/rules/chn/chn-tilde.js
@@ -6,7 +6,7 @@
 		name: 'chn-tilde',
 		description: 'Chinook Jargon input keyboard - tilde',
 		date: '2024-02-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/chn-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/ckb/ckb-transliteration-arkbd.js
+++ b/rules/ckb/ckb-transliteration-arkbd.js
@@ -6,7 +6,7 @@
 		name: 'باشووری',
 		description: 'Central Kurdish keyboard based on Arabic keyboard',
 		date: '2013-07-06',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ckb-transliteration-arkbd',
 		author: 'Çalak',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ckb/ckb-transliteration-fakbd.js
+++ b/rules/ckb/ckb-transliteration-fakbd.js
@@ -6,7 +6,7 @@
 		name: 'ڕۆژھەڵاتی',
 		description: 'Central Kurdish keyboard based on Persian keyboard',
 		date: '2013-07-06',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ckb-transliteration-fakbd',
 		author: 'Çalak',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ckb/ckb-transliteration-lakbd.js
+++ b/rules/ckb/ckb-transliteration-lakbd.js
@@ -6,7 +6,7 @@
 		name: 'لاتینی',
 		description: 'Central Kurdish keyboard based on Latin keyboard',
 		date: '2013-07-06',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ckb-transliteration-lakbd',
 		author: 'Çalak',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/cko/cko-tilde.js
+++ b/rules/cko/cko-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Anufo tilde',
 		description: 'Anufo input keyboard',
 		date: '2024-11-05',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/cko-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/cyrl/cyrl-palochka.js
+++ b/rules/cyrl/cyrl-palochka.js
@@ -33,7 +33,7 @@
 		name: 'Cyrillic Palochka',
 		description: 'Palochka input method for Cyrillic',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/cyrl-palochka',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/dag/dag-tilde.js
+++ b/rules/dag/dag-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Dagbani tilde',
 		description: 'Dagbani tilde',
 		date: '2019-05-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/dag-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/de/de-transliteration.js
+++ b/rules/de/de-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Deutsch Tilde',
 		description: 'German input method',
 		date: '2012-11-20',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/de-transliteration',
 		author: 'Erik Moeller',
 		license: 'Public domain',
 		version: '1.0',

--- a/rules/din/din-fqsx.js
+++ b/rules/din/din-fqsx.js
@@ -6,7 +6,7 @@
 		name: 'FQSX replacement',
 		description: 'Dinka input method with F, Q, S and X replaced by Ɣ, Ŋ, Ɛ, and Ɔ',
 		date: '2017-04-26',
-		URL: 'https://keymanweb.com/#dib,Keyboard_dinkaweb11',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/din-fqsx',
 		author: 'Amir E. Aharoni, based on Keyman',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/din/din-tilde.js
+++ b/rules/din/din-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Dinka tilde',
 		description: 'Dinka tilde',
 		date: '2019-05-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/din-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ee/ee-tilde.js
+++ b/rules/ee/ee-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ee-tilde',
 		description: 'Ewe input keyboard',
 		date: '2018-11-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ee-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/efi/efi-tilde.js
+++ b/rules/efi/efi-tilde.js
@@ -6,7 +6,7 @@
 		name: 'efi-tilde',
 		description: 'Efik input keyboard',
 		date: '2022-05-23',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/efi-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ekp/ekp-tilde.js
+++ b/rules/ekp/ekp-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ekp-tilde',
 		description: 'Ekpeye input keyboard - tilde',
 		date: '2024-05-17',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/el-kbd',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/el/el-kbd.js
+++ b/rules/el/el-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Greek kbd',
 		description: 'Greek kbd keyboard layout',
 		date: '2013-02-11',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/el-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-h-f.js
+++ b/rules/eo/eo-h-f.js
@@ -6,7 +6,7 @@
 		name: 'Espernto h-f',
 		description: 'writing Esperanto-letters using Zamenhof\'s fundamental system.',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-h-f',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-h.js
+++ b/rules/eo/eo-h.js
@@ -6,7 +6,7 @@
 		name: 'Esperanto h',
 		description: 'writing Esperanto-letters adding h\'s.',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-h',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-plena.js
+++ b/rules/eo/eo-plena.js
@@ -6,7 +6,7 @@
 		name: 'Esperanto plena',
 		description: 'writing Esperanto-letters with the fundamental system and the X-system, like the default of EK.',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-plena',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-q.js
+++ b/rules/eo/eo-q.js
@@ -6,7 +6,7 @@
 		name: 'Espernto q',
 		description: 'writing Esperanto-letters adding q\'s.',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-q',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-transliteration.js
+++ b/rules/eo/eo-transliteration.js
@@ -36,7 +36,7 @@
 		name: 'Esperanto Transliteration',
 		description: 'Esperanto x-code transliteration',
 		date: '2012-10-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-transliteration',
 		author: 'Brion Vibber',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-vi.js
+++ b/rules/eo/eo-vi.js
@@ -6,7 +6,7 @@
 		name: 'Esperanto vi',
 		description: 'writing Esperanto-letters using double key press (the X-system).',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-vi',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/eo/eo-x.js
+++ b/rules/eo/eo-x.js
@@ -6,7 +6,7 @@
 		name: 'Esperanto x',
 		description: 'writing Esperanto-letters adding x\'s (the X-system).',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/eo-x',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/fa/fa-kbd.js
+++ b/rules/fa/fa-kbd.js
@@ -6,7 +6,7 @@
 		name: 'kbd',
 		description: 'Persian standard (ISIRI 9147) keyboard layout',
 		date: '2013-08-30',
-		URL: 'http://www.isiri.org/portal/files/std/9147.pdf',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/fa-kbd',
 		author: 'Ebrahim Byagowi',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ff/ff-tilde.js
+++ b/rules/ff/ff-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Fulfulde tilde',
 		description: 'Fulfulde tilde',
 		date: '2019-05-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ff-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/fi/fi-transliteration.js
+++ b/rules/fi/fi-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'translitterointi',
 		description: 'Finnish transliteration',
 		date: '2012-11-10',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/fi-transliteration',
 		author: 'Niklas Laxström',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/fo/fo-normforms.js
+++ b/rules/fo/fo-normforms.js
@@ -6,7 +6,7 @@
 		name: 'Føroyskt',
 		description: 'Faroese input method with most common form transliterated',
 		date: '2012-12-04',
-		URL: 'http://www.evertype.com/alphabets/faroese.pdf',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/fo-normforms',
 		author: 'John Erling Blad',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/fon/fon-tilde.js
+++ b/rules/fon/fon-tilde.js
@@ -6,7 +6,7 @@
 		name: 'fon-tilde',
 		description: 'Fon input keyboard',
 		date: '2018-05-18',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/fon-tilde',
 		author: 'Mahuton POSSOUPE, Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/fvr/fvr-tilde.js
+++ b/rules/fvr/fvr-tilde.js
@@ -6,7 +6,7 @@
 		name: 'fvr-tilde',
 		description: 'Fur tilde keyboard',
 		date: '2024-10-31',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/fvr-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/gaa/gaa-cqx.js
+++ b/rules/gaa/gaa-cqx.js
@@ -6,7 +6,7 @@
 		name: 'Ga - CQX replacement',
 		description: 'Ga input method with C, Q and X replaced by Ŋ, Ɛ and Ɔ',
 		date: '2016-06-23',
-		URL: 'https://www.kasahorow.org/node/260',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/gaa-cqx',
 		author: 'Amir E. Aharoni, based on Kasahorow Akan',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/gaa/gaa-tilde.js
+++ b/rules/gaa/gaa-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Ga tilde',
 		description: 'Ga tilde',
 		date: '2019-05-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/gaa-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/got/got-standard.js
+++ b/rules/got/got-standard.js
@@ -6,7 +6,7 @@
 		name: '𐌲𐌿𐍄𐌹𐍃𐌺𐌰 𐍂𐌰𐌶𐌳𐌰',
 		description: 'Gothic keyboard layout',
 		date: '2016-06-27',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/got-standard',
 		author: 'Bokareis',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/gu/gu-transliteration.js
+++ b/rules/gu/gu-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'લિપ્યંતરણ',
 		description: 'Gujarati transliteration',
 		date: '2012-10-14',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/gu-transliteration',
 		author: 'Jaldeep R Vasavada ([[User:JaldeepVasavada]]) / Amir E. Aharoni ([[User:Amire80]])',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/gur/gur-tilde.js
+++ b/rules/gur/gur-tilde.js
@@ -6,7 +6,7 @@
 		name: 'gur-tilde',
 		description: 'Farefare input keyboard',
 		date: '2021-09-25',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/gur-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ha/ha-tilde.js
+++ b/rules/ha/ha-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ha-tilde',
 		description: 'Hausa input keyboard',
 		date: '2018-11-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ha-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/he/he-standard-2012-extonly.js
+++ b/rules/he/he-standard-2012-extonly.js
@@ -6,7 +6,7 @@
 		name: 'Hebrew 2012',
 		description: 'Hebrew keyboard according to Israeli Standard 1452',
 		date: '2012-10-15',
-		URL: 'http://www.lingnu.com/he/howto/78-si1452.html',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/he-standard-2012-extonly',
 		author: 'Amir E. Aharoni (אָמִיר אֱלִישָׁע אַהֲרוֹנִי, [[User:Amire80]])',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/he/he-standard-2012.js
+++ b/rules/he/he-standard-2012.js
@@ -6,7 +6,7 @@
 		name: 'Hebrew 2012 (from English)',
 		description: 'Hebrew keyboard according to Israeli Standard 1452',
 		date: '2012-10-15',
-		URL: 'http://www.lingnu.com/he/howto/78-si1452.html',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/he-standard-2012',
 		author: 'Amir E. Aharoni (אָמִיר אֱלִישָׁע אַהֲרוֹנִי, [[User:Amire80]])',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/hi/hi-bolnagri.js
+++ b/rules/hi/hi-bolnagri.js
@@ -6,7 +6,7 @@
 		name: 'बोलनागरी',
 		description: 'BolNagri phonetic keymap for Devanagari script',
 		date: '2012-03-28',
-		URL: 'http://www.indlinux.org/wiki/index.php/BolNagri',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/hi-bolnagri',
 		author: 'G Karunakar',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/hr/hr-kbd.js
+++ b/rules/hr/hr-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Croatian kbd',
 		description: 'Croatian keyboard layout',
 		date: '2013-02-11',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/hr-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ibb/ibb-tilde.js
+++ b/rules/ibb/ibb-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ibb-tilde',
 		description: 'Ibibio input keyboard',
 		date: '2023-04-03',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ibb-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ig/ig-tilde.js
+++ b/rules/ig/ig-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ig-tilde',
 		description: 'Igbo input keyboard',
 		date: '2018-11-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ig-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/is/is-normforms.js
+++ b/rules/is/is-normforms.js
@@ -6,7 +6,7 @@
 		name: 'Íslenska',
 		description: 'Islandic input method with most common form transliterated',
 		date: '2012-12-04',
-		URL: 'http://www.evertype.com/alphabets/icelandic.pdf',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/is-normforms',
 		author: 'John Erling Blad',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/jv-java/jv-transliteration.js
+++ b/rules/jv-java/jv-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Javanese',
 		description: 'Javanese transliteration',
 		date: '2023-04-06',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/jv-transliteration',
 		author: 'Bennylin',
 		license: 'GPLv3',
 		version: '1.3',

--- a/rules/ka/ka-kbd.js
+++ b/rules/ka/ka-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Georgian kbd',
 		description: 'Georgian kbd keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ka-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ka/ka-transliteration.js
+++ b/rules/ka/ka-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'ტრანსლიტერაცია',
 		description: 'Georgian transliteration',
 		date: '2012-10-14',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ka-transliteration',
 		author: 'Ioseb Dzmanashvili (http://www.code.ge), [[User:Hooman]], Srikanth L',
 		license: 'MIT',
 		version: '1.0',

--- a/rules/kab/kab-tilde.js
+++ b/rules/kab/kab-tilde.js
@@ -6,7 +6,7 @@
 		name: 'kab-tilde',
 		description: 'Kabyle Latin tilde keyboard',
 		date: '2018-11-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kab-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/kbp/kbp-tilde.js
+++ b/rules/kbp/kbp-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Kabɩyɛ tilde',
 		description: 'Kabiye input keyboard',
 		date: '2018-12-18',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kbp-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/kcg/kcg-tilde.js
+++ b/rules/kcg/kcg-tilde.js
@@ -6,7 +6,7 @@
 		name: 'kcg-tilde',
 		description: 'Tyap input keyboard',
 		date: '2020-12-04',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kcg-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/ki/ki-tilde.js
+++ b/rules/ki/ki-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ki-tilde',
 		description: 'Kikuyu input keyboard - tilde',
 		date: '2019-01-22',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ki-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/kk/kk-arabic.js
+++ b/rules/kk/kk-arabic.js
@@ -6,7 +6,7 @@
 		name: 'Kazak arabic',
 		description: 'Kazak arabic in Arabic script keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kk-arabic',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/kk/kk-kbd.js
+++ b/rules/kk/kk-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Kazak kbd',
 		description: 'Kazak kbd in Cyrillic script keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kk-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/km/km-nidakyk.js
+++ b/rules/km/km-nidakyk.js
@@ -8,7 +8,7 @@
 		name: 'ក្តារ​ចុច​យូនីកូដ​ខ្មែរ (NiDA)',
 		description: 'NiDA Standard Khmer Unicode Keyboard',
 		date: '2016-07-07',
-		URL: 'http://www.nida.gov.kh/files/documents/How_to_type_Khmer_Unicode_ver1_1km.pdf',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/km-nidakyk',
 		author: 'Ang Iongchun',
 		license: 'Public domain',
 		version: '1.0',

--- a/rules/kn/kn-kgp.js
+++ b/rules/kn/kn-kgp.js
@@ -6,7 +6,7 @@
 		name: 'ಕಗಪ/ನುಡಿ',
 		description: 'Kannada kgp/nudi/KP Rao layout',
 		date: '2012-11-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kn-kgp',
 		author: 'Aravinda VK<mail@aravindavk.in>',
 		license: 'GPLv3,MIT',
 		version: '1.0',

--- a/rules/kn/kn-transliteration.js
+++ b/rules/kn/kn-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'ಲಿಪ್ಯಂತರಣ',
 		description: 'Kannada transliteration',
 		date: '2012-10-14',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kn-transliteration',
 		author: 'M G Harish, HP Nadig ',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ko/ko-rr.js
+++ b/rules/ko/ko-rr.js
@@ -110,7 +110,7 @@
 		name: 'Korean Revised Romanization',
 		description: 'Transliteration using Korean revised romanization',
 		date: '2023-02-04',
-		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/korean-revised-romanization',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ko-rr',
 		author: 'Anne Drew Hu',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/kr/kr-tilde.js
+++ b/rules/kr/kr-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Kanuri tilde',
 		description: 'Kanuri tilde keyboard',
 		date: '2022-06-11',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kr-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ku/ku-tr.js
+++ b/rules/ku/ku-tr.js
@@ -6,7 +6,7 @@
 		name: 'Kurdî-tr',
 		description: 'writing Kurdish-letters using the TR keyboard',
 		date: '2013-06-26',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ku-tr',
 		author: 'Ghybu',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/kus/kus-tilde.js
+++ b/rules/kus/kus-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Kusaal tilde',
 		description: 'Kusaal input keyboard',
 		date: '2022-12-11',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/kus-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/laj/laj-tilde.js
+++ b/rules/laj/laj-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Lango tilde',
 		description: 'Lango tilde',
 		date: '2024-09-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/laj-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/lg/lg-tilde.js
+++ b/rules/lg/lg-tilde.js
@@ -6,7 +6,7 @@
 		name: 'lg-tilde',
 		description: 'Luganda tilde keyboard',
 		date: '2019-03-28',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/lg-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ln/ln-tilde.js
+++ b/rules/ln/ln-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ln-tilde',
 		description: 'Lingala tilde keyboard',
 		date: '2019-03-28',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ln-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/lo/lo-kbd.js
+++ b/rules/lo/lo-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Lao kbd',
 		description: 'Lao kbd keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/lo-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/lrc/lrc-kbd.js
+++ b/rules/lrc/lrc-kbd.js
@@ -6,7 +6,7 @@
 		name: 'لۊری شومالی',
 		description: 'Northern Luri Keyboard Layout',
 		date: '2015-05-11',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/lrc-kbd',
 		author: 'Mjbmr',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/lut/lut-tulalip.js
+++ b/rules/lut/lut-tulalip.js
@@ -6,7 +6,7 @@
 		name: 'Lushootseed Tulalip',
 		description: 'Lushootseed Keyboard with Tulalip Layout',
 		date: '2014-03-01',
-		URL: 'https://github.com/jcrowgey/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/lut-tulalip',
 		author: 'Joshua Crowgey, jcrowgey@u.washington.edu',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mad/mad-tilde.js
+++ b/rules/mad/mad-tilde.js
@@ -6,7 +6,7 @@
 		name: 'mad-tilde',
 		description: 'Madurese tilde keyboard',
 		date: '2020-12-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mad-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1',

--- a/rules/maw/maw-tilde.js
+++ b/rules/maw/maw-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Mampruli tilde',
 		description: 'Mampruli tilde',
 		date: '2024-11-05',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/maw-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mg/mg-tilde.js
+++ b/rules/mg/mg-tilde.js
@@ -6,7 +6,7 @@
 		name: 'mg-tilde',
 		description: 'Malagasy tilde keyboard',
 		date: '2019-03-28',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mg-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ml/ml-inscript.js
+++ b/rules/ml/ml-inscript.js
@@ -6,7 +6,7 @@
 		name: 'ഇൻസ്ക്രിപ്റ്റ്',
 		description: 'Malayalam InScript',
 		date: '2012-10-03',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ml-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ml/ml-inscript2.js
+++ b/rules/ml/ml-inscript2.js
@@ -6,7 +6,7 @@
 		name: 'ഇൻസ്ക്രിപ്റ്റ് 2',
 		description: 'Enhanced InScript for Malayalam InScript',
 		date: '2013-01-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ml-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ml/ml-transliteration.js
+++ b/rules/ml/ml-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'ലിപ്യന്തരണം',
 		description: 'Malayalam Transliteration based input method',
 		date: '2012-10-03',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ml-transliteration',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mn/mn-cyrl.js
+++ b/rules/mn/mn-cyrl.js
@@ -12,7 +12,7 @@
 		name: 'Mongolian Cyrillic',
 		description: 'Mongolian Cyrillic Input Method',
 		date: '2012-10-25',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mn-cyrl',
 		author: 'Kevin K.S. Leung, <sprconan@gmail.com>',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mnc/mnc-ali.js
+++ b/rules/mnc/mnc-ali.js
@@ -6,7 +6,7 @@
 		name: 'Manchu Ali-gali Scripts',
 		description: 'Manchu Ali-gali Scripts',
 		date: '2014-4-22',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mnc-ali',
 		author: 'Feilong Huang, <huangfeilong@gmail.com>',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mnc/mnc-scripts.js
+++ b/rules/mnc/mnc-scripts.js
@@ -6,7 +6,7 @@
 		name: 'Manchu Scripts',
 		description: 'Manchu Scripts',
 		date: '2014-4-22',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mnc-scripts',
 		author: 'Feilong Huang, <huangfeilong@gmail.com>',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mni/mni-inscript2.js
+++ b/rules/mni/mni-inscript2.js
@@ -6,7 +6,7 @@
 		name: 'ইনস্ক্ৰিপ্ট ২',
 		description: 'Enhanced InScript keyboard for Manipuri language using Bengali script',
 		date: '2013-02-13',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mni-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mns/mns-backslash.js
+++ b/rules/mns/mns-backslash.js
@@ -6,7 +6,7 @@
 		name: 'mns-backslash',
 		description: 'Mansi backslash keyboard',
 		date: '2024-11-05',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mns-backslash',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mr/mr-inscript.js
+++ b/rules/mr/mr-inscript.js
@@ -6,6 +6,7 @@
 		name: 'मराठी लिपी',
 		description: 'InScript keyboard for Marathi script',
 		date: '2012-10-14',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mr-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mr/mr-inscript2.js
+++ b/rules/mr/mr-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'मराठी इनस्क्रिप्ट २',
 		description: 'Enhanced InScript keyboard for Marathi language',
 		date: '2012-11-06',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mr-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mr/mr-phonetic.js
+++ b/rules/mr/mr-phonetic.js
@@ -6,6 +6,7 @@
 		name: 'फोनेटिक',
 		description: 'Phonetic keyboard for Marathi language',
 		date: '2013-02-09',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mr-phonetic',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mr/mr-transliteration.js
+++ b/rules/mr/mr-transliteration.js
@@ -6,6 +6,7 @@
 		name: 'अक्षरांतरण',
 		description: 'Transliteration keyboard for Marathi script',
 		date: '2012-10-14',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mr-transliteration',
 		author: 'Pathak A B',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mul-bf/mul-bf.js
+++ b/rules/mul-bf/mul-bf.js
@@ -6,7 +6,7 @@
 		name: 'Burkina Faso tilde',
 		description: 'Burkina Faso tilde keyboard',
 		date: '2022-02-14',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mul-bf',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mul-click/mul-click-tilde.js
+++ b/rules/mul-click/mul-click-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Click tilde',
 		description: 'Click input keyboard',
 		date: '2024-09-24',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mul-click-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/mul-cm/mul-cm.js
+++ b/rules/mul-cm/mul-cm.js
@@ -6,7 +6,7 @@
 		name: 'Cameroon Languages tilde',
 		description: 'General Alphabet of Cameroon Languages tilde keyboard',
 		date: '2022-02-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/mul-cm',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/my/my-mm3.js
+++ b/rules/my/my-mm3.js
@@ -6,7 +6,7 @@
 		name: 'မြန်မာ၃ လက်ကွက်',
 		description: 'Myanmar3 keyboard layout',
 		date: '2014-10-28',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/my-mm3',
 		author: 'Lionslayer',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/my/my-xkb.js
+++ b/rules/my/my-xkb.js
@@ -6,7 +6,7 @@
 		name: 'မြန်မာဘာသာ xkb',
 		description: 'Myanmar xkb keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/my-xkb',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.01',

--- a/rules/ne/ne-inscript.js
+++ b/rules/ne/ne-inscript.js
@@ -6,6 +6,7 @@
 		name: 'इनस्क्रिप्ट',
 		description: 'InScript keyboard for Nepali script',
 		date: '2012-10-14',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ne-inscript',
 		author: 'Bhawani Gautam',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ne/ne-inscript2.js
+++ b/rules/ne/ne-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'नेपाळी इनस्क्रिप्ट २',
 		description: 'Enhanced InScript keyboard for Nepali language',
 		date: '2012-11-06',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ne-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ne/ne-rom.js
+++ b/rules/ne/ne-rom.js
@@ -6,6 +6,7 @@
 		name: 'Nepali Romanized',
 		description: 'Nepali Romanized keyboard layout',
 		date: '2013-02-12',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ne-rom',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ne/ne-trad.js
+++ b/rules/ne/ne-trad.js
@@ -6,6 +6,7 @@
 		name: 'Nepali Traditional',
 		description: 'Nepali Traditional keyboard layout',
 		date: '2013-02-12',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ne-trad',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ne/ne-transliteration.js
+++ b/rules/ne/ne-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'लिप्यंतरण',
 		description: 'Nepali transliteration',
 		date: '2012-10-14',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ne-transliteration',
 		author: 'Junaid P V ([[user:Junaidpv]]) and Bhawani Gautam ([[user:Bhawani Gautam]])',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/nia/nia-tilde.js
+++ b/rules/nia/nia-tilde.js
@@ -6,7 +6,7 @@
 		name: 'nia-tilde',
 		description: 'Nias tilde keyboard',
 		date: '2021-01-13',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/nia-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1',

--- a/rules/nmz/nmz-tilde.js
+++ b/rules/nmz/nmz-tilde.js
@@ -6,7 +6,7 @@
 		name: 'nmz-tilde',
 		description: 'Nawdm tilde keyboard',
 		date: '2021-11-01',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/nmz-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/nqo/nqo-standard-qwerty.js
+++ b/rules/nqo/nqo-standard-qwerty.js
@@ -6,7 +6,7 @@
 		name: "N'Ko standard qwerty",
 		description: "N'Ko standard qwerty",
 		date: '2019-04-26',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/nqo-standard-qwerty',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/nqo/nqo-transliteration.js
+++ b/rules/nqo/nqo-transliteration.js
@@ -6,7 +6,7 @@
 		name: "N'Ko transliteration",
 		description: "N'Ko transliteration",
 		date: '2019-04-26',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/nqo-transliteration',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/nso/nso-tilde.js
+++ b/rules/nso/nso-tilde.js
@@ -6,7 +6,7 @@
 		name: 'nso-tilde',
 		description: 'Northern Sotho input keyboard',
 		date: '2018-12-02',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/nso-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/nus/nus-tilde.js
+++ b/rules/nus/nus-tilde.js
@@ -6,7 +6,7 @@
 		name: 'nus-tilde',
 		description: 'Nuer input keyboard',
 		date: '2021-01-18',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/nus-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/or/or-OdiScript.js
+++ b/rules/or/or-OdiScript.js
@@ -6,7 +6,7 @@
 		name: 'ଓଡ଼ିସ୍କ୍ରିପ୍ଟ',
 		description: 'Odia OdiScript input method',
 		date: '2015-7-28',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/or-OdiScript',
 		author: 'Manoj Sahukar and Subhashish Panigrahi',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/or/or-inscript.js
+++ b/rules/or/or-inscript.js
@@ -6,6 +6,7 @@
 		name: 'ଇନସ୍କ୍ରିପ୍ଟ',
 		description: 'InScript keyboard for Odia script',
 		date: '2012-10-14',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/or-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/or/or-inscript2.js
+++ b/rules/or/or-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'ଇନସ୍କ୍ରିପ୍ଟ2',
 		description: 'Enhanced InScript keyboard for Odia language',
 		date: '2013-02-09',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/or-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/or/or-lekhani.js
+++ b/rules/or/or-lekhani.js
@@ -6,7 +6,7 @@
 		name: 'ଫୋନେଟିକ',
 		description: 'Odia Lekhani phonetic input method',
 		date: '2012-10-14',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/or-lekhani',
 		author: 'Junaid P V, Subhashish Panigrahi and Jnanaranjan Sahu',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/or/or-phonetic.js
+++ b/rules/or/or-phonetic.js
@@ -6,7 +6,7 @@
 		name: 'ଫୋନେଟିକ',
 		description: 'Phonetic keyboard for Odia script',
 		date: '2013-02-09',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/or-phonetic',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/or/or-transliteration.js
+++ b/rules/or/or-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'ଟ୍ରାନ୍ସଲିଟରେସନ',
 		description: 'Odia Transliteration',
 		date: '2012-10-14',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/or-transliteration',
 		author: 'Junaid P V, Subhashish Panigrahi and Shitikantha Dash',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/pa/pa-inscript.js
+++ b/rules/pa/pa-inscript.js
@@ -6,6 +6,7 @@
 		name: 'Punjabi InScript',
 		description: 'InScript keyboard for Punjabi script',
 		date: '2012-10-16',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/pa-inscript',
 		author: '',
 		license: '',
 		version: '1.0',

--- a/rules/pa/pa-inscript2.js
+++ b/rules/pa/pa-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'Punjabi InScript2',
 		description: 'Enhanced InScript keyboard for Punjabi script',
 		date: '2013-11-14',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/pa-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/pa/pa-jhelum.js
+++ b/rules/pa/pa-jhelum.js
@@ -6,6 +6,7 @@
 		name: 'Punjabi Jhelum',
 		description: 'Jhelum keyboard for Punjabi script',
 		date: '2013-11-14',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/pa-jhelum',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/pa/pa-phonetic.js
+++ b/rules/pa/pa-phonetic.js
@@ -6,7 +6,7 @@
 		name: 'Punjabi Phonetic',
 		description: 'Punjabi Phonetic',
 		date: '2022-08-08',
-		URL: 'https://fedoraproject.org/wiki/I18N/Indic/PunjabiKeyboardLayouts',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/pa-phonetic',
 		author: '',
 		license: '',
 		version: '2.0',

--- a/rules/pa/pa-transliteration.js
+++ b/rules/pa/pa-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Punjabi Transliteration',
 		description: 'Punjabi transliteration',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/pa-transliteration',
 		author: 'Amir E. Aharoni, inputs from Saurabh Choudhary and Surinder Wadhawan',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ru/ru-jcuken.js
+++ b/rules/ru/ru-jcuken.js
@@ -6,7 +6,7 @@
 		name: 'Русский - ЙЦУКЕН',
 		description: 'Стандартная русская раскладка',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ru-jcuken',
 		author: 'Amir (Алексей) Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ru/ru-kbd.js
+++ b/rules/ru/ru-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Russian kbd',
 		description: 'Russian kbd keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ru-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ru/ru-phonetic.js
+++ b/rules/ru/ru-phonetic.js
@@ -6,7 +6,7 @@
 		name: 'Russian phonetic',
 		description: 'Russian phonetic keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ru-phonetic',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ru/ru-yawerty.js
+++ b/rules/ru/ru-yawerty.js
@@ -6,7 +6,7 @@
 		name: 'Russian YAWERTY',
 		description: 'Russian YAWERTY keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ru-yawerty',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sa/sa-iast.js
+++ b/rules/sa/sa-iast.js
@@ -6,7 +6,7 @@
 		name: 'Romanized',
 		description: 'Romanized input method for Sanskrit with IAST/ISO 15919 convention. Original author William Giddings <wjgiddings@googlemail.com>',
 		date: '2013-03-18',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sa-iast',
 		author: 'Runa Bhattacharjee',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sa/sa-inscript.js
+++ b/rules/sa/sa-inscript.js
@@ -6,6 +6,7 @@
 		name: 'Sanskrit InScript',
 		description: 'Inscript keyboard for Sanskrit script',
 		date: '2012-10-16',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sa-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sa/sa-inscript2.js
+++ b/rules/sa/sa-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'संस्कृत इनस्क्रिप्ट २',
 		description: 'Enhanced InScript keyboard for Sanskrit language',
 		date: '2012-11-06',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sa-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sa/sa-transliteration.js
+++ b/rules/sa/sa-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Sanskrit Transliteration',
 		description: 'Sanskrit transliteration',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sa-transliteration',
 		author: 'Junaid P V and Naveen Shankar',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sah/sah-transliteration.js
+++ b/rules/sah/sah-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Sakha Transliteration',
 		description: 'Sakha transliteration',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sah-transliteration',
 		author: 'Amir (Алексей) Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sat/sat-inscript2.js
+++ b/rules/sat/sat-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'संताली इनस्क्रिप्ट २',
 		description: 'Enhanced InScript Devanagari keyboard for Santali language',
 		date: '2013-20-13',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sat-InScript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sat/sat-sarjom-baha.js
+++ b/rules/sat/sat-sarjom-baha.js
@@ -6,6 +6,7 @@
 		name: 'Sarjom Baha',
 		description: 'Phonetic Ol Chiki keyboard, Sarjom Baha for Santali language',
 		date: '2016-03-29',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sat-Sarjom_baha',
 		author: 'Jnanaranjan Sahu',
 		license: 'GPLv3',
 		version: '1.01',

--- a/rules/sd/sd-inscript2.js
+++ b/rules/sd/sd-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'सिंधी इनस्क्रिप्ट २',
 		description: 'Enhanced InScript keyboard for Sindhi language',
 		date: '2013-20-13',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sd-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sdh/sdh-kbd.js
+++ b/rules/sdh/sdh-kbd.js
@@ -6,7 +6,7 @@
 		name: 'کوردی خوارگ',
 		description: 'Southern Kurdish Keyboard Layout',
 		date: '2015-05-03',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sdh-kbd',
 		author: 'Mjbmr',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/se/se-normforms.js
+++ b/rules/se/se-normforms.js
@@ -6,7 +6,7 @@
 		name: 'Davvisámegiella',
 		description: 'Northern Sami input method',
 		date: '2012-12-04',
-		URL: 'http://giellatekno.uit.no/doc/infra/samihtml.html',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/se-normforms',
 		author: 'John Erling Blad',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ses/ses-tilde.js
+++ b/rules/ses/ses-tilde.js
@@ -6,7 +6,7 @@
 		name: 'ses-tilde',
 		description: 'Koyraboro Senni Songhay input keyboard - tilde',
 		date: '2019-01-22',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ses-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sg/sg-tilde.js
+++ b/rules/sg/sg-tilde.js
@@ -6,7 +6,7 @@
 		name: 'sg-tilde',
 		description: 'Sango tilde keyboard',
 		date: '2019-03-28',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sg-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/si/si-singlish.js
+++ b/rules/si/si-singlish.js
@@ -6,7 +6,7 @@
 		name: 'Sinhalese Singlish',
 		description: 'Singlish',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/si-singlish',
 		author: 'Junaid P V and Nishantha Anuruddha',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/sk/sk-kbd.js
+++ b/rules/sk/sk-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Slovak kbd',
 		description: 'Slovak kbd keyboard layout',
 		date: '2013-06-26',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sk-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.1',

--- a/rules/sr/sr-kbd.js
+++ b/rules/sr/sr-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Serbian keyboard',
 		description: 'Serbian keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sr-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/st/st-tilde.js
+++ b/rules/st/st-tilde.js
@@ -6,7 +6,7 @@
 		name: 'st-tilde',
 		description: 'Sotho tilde keyboard',
 		date: '2019-03-28',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/st-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/su/su-keyboard.js
+++ b/rules/su/su-keyboard.js
@@ -6,7 +6,7 @@
 		name: 'su-keyboard',
 		description: 'Sundanese keyboard',
 		date: '2023-05-07',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/su-keyboard',
 		author: 'Pijri Paijar',
 		license: 'GPLv3',
 		version: '1',

--- a/rules/sv/sv-normforms.js
+++ b/rules/sv/sv-normforms.js
@@ -6,7 +6,7 @@
 		name: 'Svenska',
 		description: 'Swedish input method with most common form transliterated',
 		date: '2012-12-04',
-		URL: 'http://www.evertype.com/alphabets/swedish.pdf',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/sv-normforms',
 		author: 'John Erling Blad',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ta/ta-99.js
+++ b/rules/ta/ta-99.js
@@ -6,7 +6,7 @@
 		name: 'தமிழ்99',
 		description: 'Tamil 99 Keyboard',
 		date: '2012-11-20',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ta-99',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ta/ta-bamini.js
+++ b/rules/ta/ta-bamini.js
@@ -6,7 +6,7 @@
 		name: 'பாமினி',
 		description: 'Tamil Bamini input method',
 		date: '2012-10-03',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ta-bamini',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ta/ta-inscript.js
+++ b/rules/ta/ta-inscript.js
@@ -6,7 +6,7 @@
 		name: 'இன்ஸ்கிரிப்ட்',
 		description: 'Tamil InScript Keyboard',
 		date: '2012-11-20',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ta-inscript',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ta/ta-inscript2.js
+++ b/rules/ta/ta-inscript2.js
@@ -6,7 +6,7 @@
 		name: 'இன்ஸ்கிரிப்ட் 2',
 		description: 'Enhanced InScript Keyboard for Tamil',
 		date: '2013-01-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ta-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ta/ta-transliteration.js
+++ b/rules/ta/ta-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'எழுத்துப்பெயர்ப்பு',
 		description: 'Tamil Transliteration based input method',
 		date: '2012-10-03',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ta-transliteration',
 		author: 'Junaid P V',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/te/te-apple.js
+++ b/rules/te/te-apple.js
@@ -6,6 +6,7 @@
 		name: 'ఆపిల్',
 		description: 'Apple keyboard layout for Telugu',
 		date: '2014-12-27',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/te-apple',
 		author: 'Praveen Illa',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/te/te-inscript.js
+++ b/rules/te/te-inscript.js
@@ -6,6 +6,7 @@
 		name: 'ఇన్\u200dస్క్రిప్ట్',
 		description: 'Inscript keyboard for Telugu script',
 		date: '2012-10-16',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/te-inscript',
 		author: 'Veeven',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/te/te-inscript2.js
+++ b/rules/te/te-inscript2.js
@@ -6,6 +6,7 @@
 		name: 'ఇన్\u200dస్క్రిప్ట్ 2',
 		description: 'Enhanced InScript keyboard for Telugu script',
 		date: '2013-01-16',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/te-inscript2',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/te/te-modular.js
+++ b/rules/te/te-modular.js
@@ -6,6 +6,7 @@
 		name: 'మాడ్యులర్',
 		description: 'Modular keyboard layout for Telugu',
 		date: '2014-12-31',
+		URL: '',
 		author: 'Praveen Illa',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/te/te-transliteration.js
+++ b/rules/te/te-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'లిప్యంతరీకరణ',
 		description: 'Telugu Transliteration based on RTS',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/te-transliteration',
 		author: 'Veeven, Junaid P V, Rahimanuddin Shaik',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/th/th-kedmanee.js
+++ b/rules/th/th-kedmanee.js
@@ -6,7 +6,7 @@
 		name: 'Thai Kedmanee',
 		description: 'Thai Kedmanee Input Method',
 		date: '2012-10-25',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/th-kedmanee',
 		author: 'Kevin K.S. Leung, <sprconan@gmail.com>',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/th/th-pattachote.js
+++ b/rules/th/th-pattachote.js
@@ -6,7 +6,7 @@
 		name: 'Thai Pattachote',
 		description: 'Thai Pattachote Input Method',
 		date: '2012-10-25',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/th-pattachote',
 		author: 'Kevin K.S. Leung, <sprconan@gmail.com>',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ti/ti-geezim.js
+++ b/rules/ti/ti-geezim.js
@@ -6,7 +6,7 @@
 		name: 'Tigrinya GeezIM',
 		description: 'Tigrinya input method based on GeezIME scheme',
 		date: '2017-01-22',
-		URL: 'http://type.geezlab.com',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ti-geezim',
 		author: 'Fitsum Gaim, <fitsum@geezlab.com>',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/tn/tn-tilde.js
+++ b/rules/tn/tn-tilde.js
@@ -6,7 +6,7 @@
 		name: 'tn-tilde',
 		description: 'Setswana input keyboard',
 		date: '2022-07-19',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/tn-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/udm/udm-alt.js
+++ b/rules/udm/udm-alt.js
@@ -6,7 +6,7 @@
 		name: 'Удмурт ALT',
 		description: 'Удмурт ALT',
 		date: '2013-03-17',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/udm-alt',
 		author: 'Amir (Алексей) Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ug/ug-kbd.js
+++ b/rules/ug/ug-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Uyghur kbd',
 		description: 'Uyghur kbd keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ug-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/uk/uk-kbd.js
+++ b/rules/uk/uk-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Українська',
 		description: 'Ukrainian kbd keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/uk-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ur/ur-transliteration.js
+++ b/rules/ur/ur-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Urdu Transliteration',
 		description: 'Urdu Transliteration based on RTS',
 		date: '2012-10-16',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ur-transliteration',
 		author: 'Mohammed Imran Tabani',
 		license: '',
 		version: '1.0',

--- a/rules/uz/uz-kbd.js
+++ b/rules/uz/uz-kbd.js
@@ -6,7 +6,7 @@
 		name: 'Uzbek keyboard',
 		description: 'Uzbek input method with Russian keyboard layout',
 		date: '2013-02-12',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/uz-kbd',
 		author: 'Parag Nemade',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/vai/vai-transliteration.js
+++ b/rules/vai/vai-transliteration.js
@@ -6,7 +6,7 @@
 		name: 'Vai Transliteration',
 		description: 'Vai Transliteration, based on the SIL Keyman layout found at https://github.com/keymanapp/keyboards/tree/master/release/sil/sil_vai/source, with extensions',
 		date: '2019-05-08',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/vai-transliteration',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/ve/ve-tilde.js
+++ b/rules/ve/ve-tilde.js
@@ -6,7 +6,7 @@
 		name: 've-tilde',
 		description: 'Venda input keyboard',
 		date: '2018-12-02',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/ve-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/vec/vec-GVU.js
+++ b/rules/vec/vec-GVU.js
@@ -6,7 +6,7 @@
 		name: 'Vèneto GVU',
 		description: 'Venetian input method.',
 		date: '2020-03-23',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/vec-GVU',
 		author: 'Vajotwo and GatoSelvadego (Wikipedia users)',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/wo/wo-tilde.js
+++ b/rules/wo/wo-tilde.js
@@ -6,7 +6,7 @@
 		name: 'Wolof tilde',
 		description: 'Wolof tilde',
 		date: '2019-05-06',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/wo-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/yo/yo-tilde.js
+++ b/rules/yo/yo-tilde.js
@@ -6,7 +6,7 @@
 		name: 'yo-tilde',
 		description: 'Yoruba input keyboard - tilde',
 		date: '2018-11-30',
-		URL: 'https://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/yo-tilde',
 		author: 'Amir E. Aharoni',
 		license: 'GPLv3',
 		version: '1.0',

--- a/rules/zh/zh-latn-pinyin-transliteration.js
+++ b/rules/zh/zh-latn-pinyin-transliteration.js
@@ -6,7 +6,7 @@
 		name: '拼音符号输入法 / 拼音符號輸入法',
 		description: 'Mandarin Hanyu Pinyin Transliteration input method',
 		date: '2018-12-28',
-		URL: 'http://github.com/wikimedia/jquery.ime',
+		URL: 'https://www.mediawiki.org/wiki/Help:Extension:UniversalLanguageSelector/Input_methods/zh-pinyin-transliteration',
 		author: 'Yuping Zuo',
 		license: 'MIT',
 		version: '1.0',


### PR DESCRIPTION
I updated each URL value for the necessary input method ( input methods that do not have url or have this repo as their url link for documentation on that particular input method ) with that of their various media wiki documentation.
I also looked up the urls provided by some input methods and if they are no longer working (404 error page) I replace them with that of Mediawiki. This is to resolve the issue raised on [Phabricator-T381067](https://phabricator.wikimedia.org/T381067).