### PR TITLE
node.js.yml: Run on more versions up to 26.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 17.x, 18.x]
+        node-version: [16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x, 25.x, 26.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Probably should drop some of these...

But let's see which work to begin with